### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,14 +61,14 @@ module.exports = {
 `optimizeCss` should be added to the list of `vite.plugins`. Take care to only run the plugin when building for production.
 
 ```js
-// svelte.config.cjs
-const static = require("@sveltejs/adapter-static");
-const { optimizeCss } = require("carbon-preprocess-svelte");
+// svelte.config.js
+import adapter from "@sveltejs/adapter-static";
+import { optimizeCss } from "carbon-preprocess-svelte";
 
-module.exports = {
+export default {
   kit: {
     target: "#svelte",
-    adapter: static(),
+    adapter: adapter(),
     vite: {
       optimizeDeps: {
         include: ["carbon-components-svelte", "clipboard-copy"],
@@ -135,10 +135,10 @@ module.exports = {
 #### Usage
 
 ```js
-// svelte.config.cjs
-const { elements } = require("carbon-preprocess-svelte");
+// svelte.config.js
+import { elements } from "carbon-preprocess-svelte";
 
-module.exports = {
+export default {
   preprocess: [elements()],
 };
 ```
@@ -182,10 +182,10 @@ The only required attribute is `name`, which represents the module name of the i
 #### Usage
 
 ```js
-// svelte.config.cjs
-const { icons } = require("carbon-preprocess-svelte");
+// svelte.config.js
+import { icons } from "carbon-preprocess-svelte";
 
-module.exports = {
+export default {
   preprocess: [icons()],
 };
 ```
@@ -207,10 +207,10 @@ The only required attribute is `name`, which represents the module name of the p
 #### Usage
 
 ```js
-// svelte.config.cjs
-const { pictograms } = require("carbon-preprocess-svelte");
+// svelte.config.js
+import { pictograms } from "carbon-preprocess-svelte";
 
-module.exports = {
+export default {
   preprocess: [pictograms()],
 };
 ```
@@ -246,10 +246,10 @@ const headings = [
 #### Usage
 
 ```js
-// svelte.config.cjs
-const { collectHeadings } = require("carbon-preprocess-svelte");
+// svelte.config.js
+import { collectHeadings } from "carbon-preprocess-svelte";
 
-module.exports = {
+export default {
   preprocess: [
     collectHeadings({
       afterCollect: (headings, content) => {
@@ -294,10 +294,10 @@ interface CollectHeadingsOptions {
 ## Presets
 
 ```js
-// svelte.config.cjs
-const { presetCarbon } = require("carbon-preprocess-svelte");
+// svelte.config.js
+import { presetCarbon } from "carbon-preprocess-svelte";
 
-module.exports = {
+export default {
   preprocess: presetCarbon(),
 
   // if using other preprocessors

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "module": "./dist/index.mjs",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
   "scripts": {
     "build:api": "run-p build:api:*",
     "build:api:components": "ts-node src/build/build-components",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
-import { join } from "path";
-
 export const CARBON_SVELTE = {
   components: "carbon-components-svelte",
   icons: "carbon-icons-svelte",
@@ -12,10 +10,10 @@ export const LATEST_MAJOR_VERSION = {
   [CARBON_SVELTE.pictograms]: "11",
 };
 
-export const API_COMPONENTS = join(__dirname, `${CARBON_SVELTE.components}.js`);
-export const API_ELEMENTS = join(__dirname, "carbon-elements.js");
-export const API_ICONS = join(__dirname, "carbon-icons.js");
-export const API_PICTOGRAMS = join(__dirname, "carbon-pictograms.js");
+export const API_COMPONENTS = `src/${CARBON_SVELTE.components}.js`;
+export const API_ELEMENTS = "src/carbon-elements.js";
+export const API_ICONS = "src/carbon-icons.js";
+export const API_PICTOGRAMS = "src/carbon-pictograms.js";
 
 export const EXT_SVELTE = /\.(svelte)$/;
 export const EXT_CSS = /\.(css)$/;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,6 @@
 export * from "./preprocessors";
 export * from "./extractors";
-export * from "./plugins";
+
+// TODO: restore
+// export * from "./plugins";
 export * from "./presets";

--- a/src/preprocessors/elements.ts
+++ b/src/preprocessors/elements.ts
@@ -135,9 +135,15 @@ export function elements(
                                 token as TokenUI
                               ][theme];
 
+                          const oldValue = getContent(child.value);
+                          const newValue = oldValue.replace(
+                            childValue.value,
+                            Value
+                          );
+
                           replaceContent(
                             node,
-                            `${child.property}: ${Value}`,
+                            `${child.property}: ${newValue}`,
                             getContent(child)
                           );
 

--- a/src/preprocessors/elements.ts
+++ b/src/preprocessors/elements.ts
@@ -96,73 +96,48 @@ export function elements(
                   )?.value;
                 }
 
-                const Value = child.value.children
-                  .map((childValue) => {
-                    if (childValue.type === "String") {
-                      const token = childValue.value.replace(/(\"|\')/g, "");
+                child.value.children.forEach((childValue) => {
+                  if (childValue.type === "String") {
+                    const token = childValue.value.replace(/(\"|\')/g, "");
 
-                      if (
-                        token !== undefined &&
-                        token in carbonElements.elements.tokens
-                      ) {
-                        const tokenValue =
-                          carbonElements.elements.tokens[token as Token];
-                        if (child.property in TOKEN_TYPE) {
-                          if (
-                            (tokenValue as TokenTypeStyles).breakpoints.length >
-                            0
-                          ) {
-                            // TODO: generate responsive styles
-                          }
-
-                          replaceContent(
-                            node,
-                            (tokenValue as TokenTypeStyles).css,
-                            getContent(child)
-                          );
-
-                          return (tokenValue as TokenTypeStyles).css;
+                    if (
+                      token !== undefined &&
+                      token in carbonElements.elements.tokens
+                    ) {
+                      const tokenValue =
+                        carbonElements.elements.tokens[token as Token];
+                      if (child.property in TOKEN_TYPE) {
+                        if (
+                          (tokenValue as TokenTypeStyles).breakpoints.length > 0
+                        ) {
+                          // TODO: generate responsive styles
                         }
 
-                        if (token in carbonElements.elements.tokens_ui) {
-                          let Value: TokenUI | string;
-
-                          if (theme === "all" || cssVars)
-                            Value = `var(--cds-${token})`;
-                          else
-                            Value =
-                              carbonElements.elements.tokens_ui[
-                                token as TokenUI
-                              ][theme];
-
-                          const oldValue = getContent(child.value);
-                          const newValue = oldValue.replace(
-                            childValue.value,
-                            Value
-                          );
-
-                          replaceContent(
-                            node,
-                            `${child.property}: ${newValue}`,
-                            getContent(child)
-                          );
-
-                          if (theme === "all") return `var(--cds-${token})`;
-                          return carbonElements.elements.tokens_ui[
-                            token as TokenUI
-                          ][theme];
-                        }
-
-                        const oldValue = getContent(child.value);
-
-                        let newValue = oldValue.replace(
-                          childValue.value,
-                          tokenValue as string
+                        replaceContent(
+                          node,
+                          (tokenValue as TokenTypeStyles).css,
+                          getContent(child)
                         );
 
-                        if (hasOperator && operatorValue !== undefined) {
-                          newValue = `calc(${tokenValue} ${operator} ${operatorValue})`;
-                        }
+                        return (tokenValue as TokenTypeStyles).css;
+                      }
+
+                      if (token in carbonElements.elements.tokens_ui) {
+                        let Value: TokenUI | string;
+
+                        if (theme === "all" || cssVars)
+                          Value = `var(--cds-${token})`;
+                        else
+                          Value =
+                            carbonElements.elements.tokens_ui[token as TokenUI][
+                              theme
+                            ];
+
+                        const oldValue = getContent(child.value);
+                        const newValue = oldValue.replace(
+                          childValue.value,
+                          Value
+                        );
 
                         replaceContent(
                           node,
@@ -170,21 +145,35 @@ export function elements(
                           getContent(child)
                         );
 
-                        return tokenValue;
-                      } else {
-                        console.warn(
-                          `[carbon:elements] Invalid token "${token}"`
-                        );
+                        if (theme === "all") return `var(--cds-${token})`;
+                        return carbonElements.elements.tokens_ui[
+                          token as TokenUI
+                        ][theme];
                       }
+
+                      const oldValue = getContent(child.value);
+
+                      let newValue = oldValue.replace(
+                        childValue.value,
+                        tokenValue as string
+                      );
+
+                      if (hasOperator && operatorValue !== undefined) {
+                        newValue = `calc(${tokenValue} ${operator} ${operatorValue})`;
+                      }
+
+                      replaceContent(
+                        node,
+                        `${child.property}: ${newValue}`,
+                        getContent(child)
+                      );
+
+                      return tokenValue;
                     }
+                  }
 
-                    return getContent(childValue);
-                  })
-                  .join(" ");
-
-                if (child.property in PROPERTY_ALIAS) return Value;
-
-                return `${child.property}: ${Value};`;
+                  return getContent(childValue);
+                });
               });
             }
 

--- a/tests/integration/input/elements.test.svelte
+++ b/tests/integration/input/elements.test.svelte
@@ -43,6 +43,7 @@
 
   @media (up: lg) {
     div {
+      content: "";
       color: transparent;
     }
   }

--- a/tests/integration/input/elements.test.svelte
+++ b/tests/integration/input/elements.test.svelte
@@ -54,4 +54,23 @@
   }
   
   @media (bp: xlg) {}
+
+  @media (down: md) {
+    :global(.info-card:not(:nth-child(2))) {
+      border-top: 1px solid "ui-03";
+      padding-top: "spacing-09";
+    }
+  }
+
+  @media (bp: md) {
+    :global(.info-card:not(:nth-child(odd))) {
+      border-left: 1px solid "ui-03";
+    }
+  }
+
+  @media (between: 321px) and (md) {
+    p {
+      max-width: 75%;
+    }
+  }
 </style>

--- a/tests/integration/output/elements.test.svelte
+++ b/tests/integration/output/elements.test.svelte
@@ -54,4 +54,23 @@
   }
   
   @media (min-width: 82rem) {}
+
+  @media (max-width: 42rem) {
+    :global(.info-card:not(:nth-child(2))) {
+      border-top: 1px solid #e0e0e0;
+      padding-top: 3rem;
+    }
+  }
+
+  @media (min-width: 42rem) {
+    :global(.info-card:not(:nth-child(odd))) {
+      border-left: 1px solid #e0e0e0;
+    }
+  }
+
+  @media (min-width: 321px) and (max-width: 42rem) {
+    p {
+      max-width: 75%;
+    }
+  }
 </style>

--- a/tests/integration/output/elements.test.svelte
+++ b/tests/integration/output/elements.test.svelte
@@ -43,6 +43,7 @@
 
   @media (min-width: 66rem) {
     div {
+      content: "";
       color: transparent;
     }
   }

--- a/tests/unit/api.test.ts
+++ b/tests/unit/api.test.ts
@@ -5,7 +5,8 @@ assert.strictEqual(typeof api.collectHeadings, "function");
 assert.strictEqual(typeof api.elements, "function");
 assert.strictEqual(typeof api.extractSelectors, "function");
 assert.strictEqual(typeof api.icons, "function");
-assert.strictEqual(typeof api.optimizeCss, "function");
+// TODO: uncomment
+// assert.strictEqual(typeof api.optimizeCss, "function");
 assert.strictEqual(typeof api.optimizeImports, "function");
 assert.strictEqual(typeof api.optimizeCarbonImports, "function");
 assert.strictEqual(typeof api.pictograms, "function");


### PR DESCRIPTION
**Fixes**

- elements: only replace token in property instead of the entire property
- elements: do not emit warning if token is falsy
- add exports map to `package.json` so `svelte.config.js` works properly
- temporarily omit `optimizeCss` plugin from library

**Documentation**

- use ESM instead of CJS syntax in `svelte.config.js` usage examples