### PR TITLE
parse TypeScript syntax in optimizeCss plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ interface ElementsOptions {
    * Setting to "all" will also enable `cssVars`
    * @default "white"
    */
-  theme: v10_theme | "all";
+  theme: "white" | "g10" | "g90" | "g100" | "all";
 
   /**
    * Set to `true` for tokens to be re-written as CSS variables

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "build:api:icons": "ts-node src/build/build-icons",
     "build:api:pictograms": "ts-node src/build/build-pictograms",
     "build:lib": "run-p build:lib:*",
-    "build:lib:cjs": "esbuild src/index.ts --bundle --platform=node --target=node10.4 --external:purgecss --outfile=dist/index.js",
-    "build:lib:esm": "esbuild src/index.ts --bundle --platform=node --target=es6 --format=esm --external:purgecss --outfile=dist/index.mjs",
+    "build:lib:cjs": "esbuild src/index.ts --bundle --platform=node --target=node10.4 --external:purgecss --external:svelte-preprocess --outfile=dist/index.js",
+    "build:lib:esm": "esbuild src/index.ts --bundle --platform=node --target=es6 --format=esm --external:purgecss --external:svelte-preprocess --outfile=dist/index.mjs",
     "build:lib:types": "tsc",
     "prepack": "run-s build:api build:lib",
     "test": "run-p test:*",
@@ -30,7 +30,8 @@
     "format": "prettier --write '.'"
   },
   "dependencies": {
-    "purgecss": "^4.0.3"
+    "purgecss": "^4.0.3",
+    "svelte-preprocess": "^4.7.3"
   },
   "devDependencies": {
     "@carbon/elements": "10.31.0",

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -1,8 +1,13 @@
 import Rollup from "rollup";
+import sveltePreprocess from "svelte-preprocess";
+import { preprocess } from "svelte/compiler";
 import { extractSelectors, ExtractedSelectors } from "../extractors";
 import purgecss from "purgecss";
 import { readFile } from "../utils";
 import { EXT_SVELTE, EXT_CSS } from "../constants";
+
+// @ts-ignore
+const { typescript } = sveltePreprocess;
 
 // @ts-ignore
 const { PurgeCSS } = purgecss;
@@ -35,7 +40,10 @@ export function optimizeCss(
     async transform(code, id) {
       if (EXT_SVELTE.test(id)) {
         const source = await readFile(id, "utf-8");
-        selectors.push(...extractSelectors(source, id));
+        const result = await preprocess(source, [typescript()], {
+          filename: id,
+        });
+        selectors.push(...extractSelectors(result.code, id));
         return { code, map: null };
       }
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -92,10 +92,22 @@
   resolved "https://registry.yarnpkg.com/@types/carbon__icon-helpers/-/carbon__icon-helpers-10.7.1.tgz#f1c4d637308d87f83906aea4c7c2399592e408ef"
   integrity sha512-At07tODyK5f1tsPIg8ziZm3SHpHbfjh8YdyXLNbD9RdUa416EgUEFa6Xlxb9lgt2YHtRS/qLmy+ysbGx+zMgQg==
 
-"@types/node@^15.0.2":
+"@types/node@*", "@types/node@^15.0.2":
   version "15.0.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.2.tgz#51e9c0920d1b45936ea04341aa3e2e58d339fb67"
   integrity sha512-p68+a+KoxpoB47015IeYZYRrdqMUcpbK8re/zpFB8Ld46LHC1lPEbp3EXgkEhAYEcPvjJF6ZO+869SQ0aH1dcA==
+
+"@types/pug@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.4.tgz#8772fcd0418e3cd2cc171555d73007415051f4b2"
+  integrity sha1-h3L80EGOPNLMFxVV1zAHQVBR9LI=
+
+"@types/sass@^1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@types/sass/-/sass-1.16.0.tgz#b41ac1c17fa68ffb57d43e2360486ef526b3d57d"
+  integrity sha512-2XZovu4NwcqmtZtsBR5XYLw18T8cBCnU2USFHTnYLLHz9fkhnoEMoDsqShJIOFsFhn5aJHjweiUUdTrDGujegA==
+  dependencies:
+    "@types/node" "*"
 
 ansi-styles@^3.2.1:
   version "3.2.1"
@@ -238,6 +250,11 @@ define-properties@^1.1.3:
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
   dependencies:
     object-keys "^1.0.12"
+
+detect-indent@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.0.0.tgz#0abd0f549f69fc6659a254fe96786186b6f528fd"
+  integrity sha512-oSyFlqaTHCItVRGK5RmrmjB+CmaMOW7IaNA/kdxqhoa6d17j/5ce9O9eWXmV/KEdRwqpQA+Vqe8a8Bsybu4YnA==
 
 diff@^4.0.1:
   version "4.0.2"
@@ -476,6 +493,11 @@ memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
   integrity sha1-htcJCzDORV1j+64S3aUaR93K+bI=
+
+min-indent@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
+  integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
 minimatch@^3.0.4:
   version "3.0.4"
@@ -745,12 +767,29 @@ strip-bom@^3.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
   integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
 
+strip-indent@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
+  integrity sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+  dependencies:
+    min-indent "^1.0.0"
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+svelte-preprocess@^4.7.3:
+  version "4.7.3"
+  resolved "https://registry.yarnpkg.com/svelte-preprocess/-/svelte-preprocess-4.7.3.tgz#454fa059c2400b15e7a3caeca18993cff9df0e96"
+  integrity sha512-Zx1/xLeGOIBlZMGPRCaXtlMe4ZA0faato5Dc3CosEqwu75MIEPuOstdkH6cy+RYTUYynoxzNaDxkPX4DbrPwRA==
+  dependencies:
+    "@types/pug" "^2.0.4"
+    "@types/sass" "^1.16.0"
+    detect-indent "^6.0.0"
+    strip-indent "^3.0.0"
 
 svelte@^3.38.2:
   version "3.38.2"


### PR DESCRIPTION
**Features**

- use `svelte-preprocess` in the `optimizeCss` plugin to parse TypeScript syntax in Svelte components, #3 

**Documentation**

- list available theme options for the `elements` preprocessor