### PR TITLE
fix(include): apply test regex from entry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,13 @@ By default, the `include` preprocessor will _prepend_ content to the content blo
 
 ```js
 interface PreprocessIncludeOptions {
+  /**
+   * Specify the filename pattern to process
+   * Defaults to files ending with ".svelte"
+   * @default /\.(svelte)$/
+   */
+  test?: RegExp;
+
   script: Array<{
     /**
      * Specify the content the prepend or append
@@ -382,6 +389,7 @@ interface PreprocessIncludeOptions {
      */
     behavior?: "prepend" | "append",
   }>;
+
   markup: Array<{
     /**
      * Specify the content the prepend or append

--- a/src/preprocessors/include.ts
+++ b/src/preprocessors/include.ts
@@ -63,11 +63,14 @@ export function include(
       ) {
         script.forEach((entry) => {
           const behavior = entry.behavior ?? "prepend";
+          const test = entry.test ?? EXT_SVELTE;
 
-          if (behavior === "prepend") {
-            content = entry.content + content;
-          } else if (behavior === "append") {
-            content += entry.content;
+          if (test.test(filename)) {
+            if (behavior === "prepend") {
+              content = entry.content + content;
+            } else if (behavior === "append") {
+              content += entry.content;
+            }
           }
         });
 
@@ -89,11 +92,14 @@ export function include(
       ) {
         markup.forEach((entry) => {
           const behavior = entry.behavior ?? "prepend";
+          const test = entry.test ?? EXT_SVELTE;
 
-          if (behavior === "prepend") {
-            content = entry.content + content;
-          } else if (behavior === "append") {
-            content += entry.content;
+          if (test.test(filename)) {
+            if (behavior === "prepend") {
+              content = entry.content + content;
+            } else if (behavior === "append") {
+              content += entry.content;
+            }
           }
         });
 

--- a/src/preprocessors/include.ts
+++ b/src/preprocessors/include.ts
@@ -3,6 +3,13 @@ import { EXT_SVELTE } from "../constants";
 import { parse } from "path";
 
 interface PreprocessIncludeOptions {
+  /**
+   * Specify the filename pattern to process
+   * Defaults to files ending with ".svelte"
+   * @default /\.(svelte)$/
+   */
+  test?: RegExp;
+
   script: Array<{
     /**
      * Specify the content the prepend or append
@@ -24,6 +31,7 @@ interface PreprocessIncludeOptions {
      */
     behavior?: "prepend" | "append";
   }>;
+
   markup: Array<{
     /**
      * Specify the content the prepend or append
@@ -52,6 +60,7 @@ export function include(
 ): Pick<PreprocessorGroup, "markup" | "script"> {
   const script = options?.script ?? [];
   const markup = options?.markup ?? [];
+  const test = options?.test ?? EXT_SVELTE;
 
   return {
     script({ filename, content }) {
@@ -59,7 +68,7 @@ export function include(
         script.length > 0 &&
         filename !== undefined &&
         !/node_modules/.test(filename) &&
-        EXT_SVELTE.test(filename)
+        test.test(filename)
       ) {
         script.forEach((entry) => {
           const behavior = entry.behavior ?? "prepend";
@@ -88,7 +97,7 @@ export function include(
         // ignore SvelteKit layout/error files to prevent duplicate markup
         !/.svelte-kit/.test(filename) &&
         !/^(__layout)/.test(name) &&
-        EXT_SVELTE.test(filename)
+        test.test(filename)
       ) {
         markup.forEach((entry) => {
           const behavior = entry.behavior ?? "prepend";


### PR DESCRIPTION
**Features**

- add `test` option to `include` preprocessor to filter filenames

**Fixes**

- support custom `test` regex per script/markup object in `include` preprocessor