### PR TITLE
Upgrade carbon-components-svelte to v0.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/carbon__elements": "10.31.0",
     "@types/carbon__icon-helpers": "^10.7.1",
     "@types/node": "^15.0.2",
-    "carbon-components-svelte": "^0.38.0",
+    "carbon-components-svelte": "^0.39.0",
     "esbuild": "^0.11.19",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.2.1",

--- a/tests/integration/input/optimize-imports.test.svelte
+++ b/tests/integration/input/optimize-imports.test.svelte
@@ -1,6 +1,7 @@
 <script>
   import { Accordion as Accordion2 } from "carbon-components-svelte";
   import { Button, Button2 } from "carbon-components-svelte";
+  import { RecursiveList, TreeView, ProgressBar } from "carbon-components-svelte";
   import { Add16, Add20 } from "carbon-icons-svelte";
   import { Airplane } from "carbon-pictograms-svelte";
   import { Bridge, Item } from "carbon-pictograms-svelte";

--- a/tests/integration/output/optimize-imports.test.svelte
+++ b/tests/integration/output/optimize-imports.test.svelte
@@ -2,6 +2,9 @@
   import Accordion2 from "carbon-components-svelte/src/Accordion/Accordion.svelte";
   import Button from "carbon-components-svelte/src/Button/Button.svelte";
 
+  import RecursiveList from "carbon-components-svelte/src/RecursiveList/RecursiveList.svelte";
+import TreeView from "carbon-components-svelte/src/TreeView/TreeView.svelte";
+import ProgressBar from "carbon-components-svelte/src/ProgressBar/ProgressBar.svelte";
   import Add16 from "carbon-icons-svelte/lib/Add16/Add16.svelte";
 import Add20 from "carbon-icons-svelte/lib/Add20/Add20.svelte";
   import Airplane from "carbon-pictograms-svelte/lib/Airplane.svelte";

--- a/yarn.lock
+++ b/yarn.lock
@@ -147,13 +147,12 @@ call-bind@^1.0.0, call-bind@^1.0.2:
     function-bind "^1.1.1"
     get-intrinsic "^1.0.2"
 
-carbon-components-svelte@^0.38.0:
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/carbon-components-svelte/-/carbon-components-svelte-0.38.0.tgz#d87c68d2ba7ffb163bbb40172f1e0e7fd00313e1"
-  integrity sha512-BlCFnyTEHG/fVd0TWOMidorbTzM+8m2zZ0FaKLA3uTdECVqoVGxVjvTbunc8z/36PriG8f1tRk6Dp4mlHgOcDA==
+carbon-components-svelte@^0.39.0:
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/carbon-components-svelte/-/carbon-components-svelte-0.39.0.tgz#1acdaafd05d6334b5564106c245dd2bc79d19474"
+  integrity sha512-pz6P8JwU959YyrjJ9TUxM4O9uVjj51htGFWHAXyH2ou2TcY2t2u8DgRQMAXImAqVpwOKgwTNJ5HhnEzNyFhiSw==
   dependencies:
     carbon-icons-svelte "^10.27.0"
-    clipboard-copy "3.2.0"
     flatpickr "4.6.9"
 
 carbon-icons-svelte@^10.27.0:
@@ -169,11 +168,6 @@ chalk@^2.4.1:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-clipboard-copy@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/clipboard-copy/-/clipboard-copy-3.2.0.tgz#3c5b8651d3512dcfad295d77a9eb09e7fac8d5fb"
-  integrity sha512-vooFaGFL6ulEP1liiaWFBmmfuPm3cY3y7T9eB83ZTnYc/oFeAKsq3NcDrOkBC8XaauEE8zHQwI7k0+JSYiVQSQ==
 
 color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"


### PR DESCRIPTION
**Features**

- upgrade `carbon-components-svelte` to v0.39 to include `RecursiveList`, `TreeView` components for `optimizeImports`