### PR TITLE
docs: omit optimizeDeps from svelte.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ export default {
     target: "#svelte",
     adapter: adapter(),
     vite: {
-      optimizeDeps: { include: ["clipboard-copy"] },
       plugins: [process.env.NODE_ENV === "production" && optimizeCss()],
     },
   },
@@ -442,7 +441,6 @@ export default {
     target: "#svelte",
     adapter: adapter(),
     vite: {
-      optimizeDeps: { include: ["clipboard-copy"] },
       plugins: [process.env.NODE_ENV === "production" && optimizeCss()],
     },
   },


### PR DESCRIPTION
Including "clipboard-copy" is no longer required in carbon-components-svelte >=v0.39