### PR TITLE
breaking(optimize-imports): only optimize component imports exported from `src/index.js`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,25 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install dependencies and build the library
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Build and test the library
         run: |
           yarn
           yarn prepack
-      - name: Run unit and integration tests
-        run: yarn test
+          yarn test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /node_modules
 /dist
 /src/*.js
+!/src/carbon-components-svelte.js

--- a/src/build/build-elements.ts
+++ b/src/build/build-elements.ts
@@ -98,6 +98,7 @@ const v10_THEMES: v10_theme[] = ["white", "g10", "g90", "g100"];
     metadata: {
       package: pkg.name!,
       version: pkg.version!,
+      exports: 0,
     },
 
     tokens: {},

--- a/src/build/build-icons.ts
+++ b/src/build/build-icons.ts
@@ -34,6 +34,7 @@ interface CarbonIconsMetadata {
     metadata: {
       package: pkg.name!,
       version: pkg.version!,
+      exports: 0,
     },
     icons: {},
   };
@@ -43,6 +44,8 @@ interface CarbonIconsMetadata {
     "utf-8"
   );
   const metadata: CarbonIconsMetadata = JSON.parse(metadataJson);
+
+  icons.metadata.exports = metadata.icons.length;
 
   metadata.icons.map(({ output }) => {
     output.forEach((output) => {

--- a/src/build/build-pictograms.ts
+++ b/src/build/build-pictograms.ts
@@ -62,6 +62,7 @@ export interface CarbonPictogramsMetadata {
     metadata: {
       package: pkg.name!,
       version: pkg.version!,
+      exports: 0,
     },
     pictograms: {},
   };
@@ -71,6 +72,8 @@ export interface CarbonPictogramsMetadata {
     "utf-8"
   );
   const metadata: CarbonPictogramsMetadata = JSON.parse(metadataJson);
+
+  pictograms.metadata.exports = metadata.icons.length;
 
   metadata.icons.map(({ output }) => {
     output.forEach((output) => {

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -13,5 +13,10 @@ export interface BuildApi {
      * @example "0.32.0"
      */
     version: string;
+
+    /**
+     * Number of exports
+     */
+    exports: number;
   };
 }

--- a/src/carbon-components-svelte.js
+++ b/src/carbon-components-svelte.js
@@ -1,12 +1,10 @@
 export const components = {
   "metadata": {
     "package": "carbon-components-svelte",
-    "version": "0.62.0"
+    "version": "0.62.0",
+    "exports": 171
   },
   "components": {
-    "index": {
-      "path": "carbon-components-svelte/src/UIShell/index.js"
-    },
     "Accordion": {
       "path": "carbon-components-svelte/src/Accordion/Accordion.svelte"
     },
@@ -16,35 +14,20 @@ export const components = {
     "AccordionSkeleton": {
       "path": "carbon-components-svelte/src/Accordion/AccordionSkeleton.svelte"
     },
+    "AspectRatio": {
+      "path": "carbon-components-svelte/src/AspectRatio/AspectRatio.svelte"
+    },
     "Breadcrumb": {
       "path": "carbon-components-svelte/src/Breadcrumb/Breadcrumb.svelte"
-    },
-    "BreadcrumbSkeleton": {
-      "path": "carbon-components-svelte/src/Breadcrumb/BreadcrumbSkeleton.svelte"
     },
     "BreadcrumbItem": {
       "path": "carbon-components-svelte/src/Breadcrumb/BreadcrumbItem.svelte"
     },
+    "BreadcrumbSkeleton": {
+      "path": "carbon-components-svelte/src/Breadcrumb/BreadcrumbSkeleton.svelte"
+    },
     "Breakpoint": {
       "path": "carbon-components-svelte/src/Breakpoint/Breakpoint.svelte"
-    },
-    "breakpointObserver.d": {
-      "path": "carbon-components-svelte/src/Breakpoint/breakpointObserver.d.ts"
-    },
-    "breakpointObserver": {
-      "path": "carbon-components-svelte/src/Breakpoint/breakpointObserver.js"
-    },
-    "breakpoints.d": {
-      "path": "carbon-components-svelte/src/Breakpoint/breakpoints.d.ts"
-    },
-    "breakpoints": {
-      "path": "carbon-components-svelte/src/Breakpoint/breakpoints.js"
-    },
-    "index.d": {
-      "path": "carbon-components-svelte/src/Breakpoint/index.d.ts"
-    },
-    "AspectRatio": {
-      "path": "carbon-components-svelte/src/AspectRatio/AspectRatio.svelte"
     },
     "Button": {
       "path": "carbon-components-svelte/src/Button/Button.svelte"
@@ -55,20 +38,23 @@ export const components = {
     "ButtonSkeleton": {
       "path": "carbon-components-svelte/src/Button/ButtonSkeleton.svelte"
     },
+    "Checkbox": {
+      "path": "carbon-components-svelte/src/Checkbox/Checkbox.svelte"
+    },
+    "CheckboxSkeleton": {
+      "path": "carbon-components-svelte/src/Checkbox/CheckboxSkeleton.svelte"
+    },
+    "ClickableTile": {
+      "path": "carbon-components-svelte/src/Tile/ClickableTile.svelte"
+    },
     "CodeSnippet": {
       "path": "carbon-components-svelte/src/CodeSnippet/CodeSnippet.svelte"
     },
     "CodeSnippetSkeleton": {
       "path": "carbon-components-svelte/src/CodeSnippet/CodeSnippetSkeleton.svelte"
     },
-    "Checkbox": {
-      "path": "carbon-components-svelte/src/Checkbox/Checkbox.svelte"
-    },
-    "InlineCheckbox": {
-      "path": "carbon-components-svelte/src/Checkbox/InlineCheckbox.svelte"
-    },
-    "CheckboxSkeleton": {
-      "path": "carbon-components-svelte/src/Checkbox/CheckboxSkeleton.svelte"
+    "Column": {
+      "path": "carbon-components-svelte/src/Grid/Column.svelte"
     },
     "ComboBox": {
       "path": "carbon-components-svelte/src/ComboBox/ComboBox.svelte"
@@ -76,23 +62,14 @@ export const components = {
     "ComposedModal": {
       "path": "carbon-components-svelte/src/ComposedModal/ComposedModal.svelte"
     },
-    "ModalFooter": {
-      "path": "carbon-components-svelte/src/ComposedModal/ModalFooter.svelte"
-    },
-    "ModalHeader": {
-      "path": "carbon-components-svelte/src/ComposedModal/ModalHeader.svelte"
-    },
-    "CopyButton": {
-      "path": "carbon-components-svelte/src/CopyButton/CopyButton.svelte"
-    },
-    "ModalBody": {
-      "path": "carbon-components-svelte/src/ComposedModal/ModalBody.svelte"
+    "Content": {
+      "path": "carbon-components-svelte/src/UIShell/Content.svelte"
     },
     "ContentSwitcher": {
       "path": "carbon-components-svelte/src/ContentSwitcher/ContentSwitcher.svelte"
     },
-    "Switch": {
-      "path": "carbon-components-svelte/src/ContentSwitcher/Switch.svelte"
+    "ContextMenu": {
+      "path": "carbon-components-svelte/src/ContextMenu/ContextMenu.svelte"
     },
     "ContextMenuDivider": {
       "path": "carbon-components-svelte/src/ContextMenu/ContextMenuDivider.svelte"
@@ -100,17 +77,332 @@ export const components = {
     "ContextMenuGroup": {
       "path": "carbon-components-svelte/src/ContextMenu/ContextMenuGroup.svelte"
     },
-    "ContextMenu": {
-      "path": "carbon-components-svelte/src/ContextMenu/ContextMenu.svelte"
+    "ContextMenuOption": {
+      "path": "carbon-components-svelte/src/ContextMenu/ContextMenuOption.svelte"
     },
     "ContextMenuRadioGroup": {
       "path": "carbon-components-svelte/src/ContextMenu/ContextMenuRadioGroup.svelte"
     },
-    "ContextMenuOption": {
-      "path": "carbon-components-svelte/src/ContextMenu/ContextMenuOption.svelte"
+    "CopyButton": {
+      "path": "carbon-components-svelte/src/CopyButton/CopyButton.svelte"
     },
     "DataTable": {
       "path": "carbon-components-svelte/src/DataTable/DataTable.svelte"
+    },
+    "DataTableSkeleton": {
+      "path": "carbon-components-svelte/src/DataTable/DataTableSkeleton.svelte"
+    },
+    "DatePicker": {
+      "path": "carbon-components-svelte/src/DatePicker/DatePicker.svelte"
+    },
+    "DatePickerInput": {
+      "path": "carbon-components-svelte/src/DatePicker/DatePickerInput.svelte"
+    },
+    "DatePickerSkeleton": {
+      "path": "carbon-components-svelte/src/DatePicker/DatePickerSkeleton.svelte"
+    },
+    "Dropdown": {
+      "path": "carbon-components-svelte/src/Dropdown/Dropdown.svelte"
+    },
+    "DropdownSkeleton": {
+      "path": "carbon-components-svelte/src/Dropdown/DropdownSkeleton.svelte"
+    },
+    "ExpandableTile": {
+      "path": "carbon-components-svelte/src/Tile/ExpandableTile.svelte"
+    },
+    "FileUploader": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploader.svelte"
+    },
+    "FileUploaderButton": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderButton.svelte"
+    },
+    "FileUploaderDropContainer": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderDropContainer.svelte"
+    },
+    "FileUploaderItem": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderItem.svelte"
+    },
+    "FileUploaderSkeleton": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderSkeleton.svelte"
+    },
+    "Filename": {
+      "path": "carbon-components-svelte/src/FileUploader/Filename.svelte"
+    },
+    "FluidForm": {
+      "path": "carbon-components-svelte/src/FluidForm/FluidForm.svelte"
+    },
+    "Form": {
+      "path": "carbon-components-svelte/src/Form/Form.svelte"
+    },
+    "FormGroup": {
+      "path": "carbon-components-svelte/src/FormGroup/FormGroup.svelte"
+    },
+    "FormItem": {
+      "path": "carbon-components-svelte/src/FormItem/FormItem.svelte"
+    },
+    "FormLabel": {
+      "path": "carbon-components-svelte/src/FormLabel/FormLabel.svelte"
+    },
+    "Grid": {
+      "path": "carbon-components-svelte/src/Grid/Grid.svelte"
+    },
+    "Header": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/Header.svelte"
+    },
+    "HeaderAction": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderAction.svelte"
+    },
+    "HeaderActionLink": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderActionLink.svelte"
+    },
+    "HeaderActionSearch": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderActionSearch.svelte"
+    },
+    "HeaderGlobalAction": {
+      "path": "carbon-components-svelte/src/UIShell/HeaderGlobalAction.svelte"
+    },
+    "HeaderNav": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNav.svelte"
+    },
+    "HeaderNavItem": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNavItem.svelte"
+    },
+    "HeaderNavMenu": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNavMenu.svelte"
+    },
+    "HeaderPanelDivider": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelDivider.svelte"
+    },
+    "HeaderPanelLink": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelLink.svelte"
+    },
+    "HeaderPanelLinks": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelLinks.svelte"
+    },
+    "HeaderSearch": {
+      "path": "carbon-components-svelte/src/UIShell/HeaderSearch.svelte"
+    },
+    "HeaderUtilities": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderUtilities.svelte"
+    },
+    "Icon": {
+      "path": "carbon-components-svelte/src/Icon/Icon.svelte"
+    },
+    "IconSkeleton": {
+      "path": "carbon-components-svelte/src/Icon/IconSkeleton.svelte"
+    },
+    "ImageLoader": {
+      "path": "carbon-components-svelte/src/ImageLoader/ImageLoader.svelte"
+    },
+    "InlineLoading": {
+      "path": "carbon-components-svelte/src/InlineLoading/InlineLoading.svelte"
+    },
+    "InlineNotification": {
+      "path": "carbon-components-svelte/src/Notification/InlineNotification.svelte"
+    },
+    "Link": {
+      "path": "carbon-components-svelte/src/Link/Link.svelte"
+    },
+    "ListBox": {
+      "path": "carbon-components-svelte/src/ListBox/ListBox.svelte"
+    },
+    "ListBoxField": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxField.svelte"
+    },
+    "ListBoxMenu": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxMenu.svelte"
+    },
+    "ListBoxMenuIcon": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxMenuIcon.svelte"
+    },
+    "ListBoxMenuItem": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxMenuItem.svelte"
+    },
+    "ListBoxSelection": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxSelection.svelte"
+    },
+    "ListItem": {
+      "path": "carbon-components-svelte/src/ListItem/ListItem.svelte"
+    },
+    "Loading": {
+      "path": "carbon-components-svelte/src/Loading/Loading.svelte"
+    },
+    "LocalStorage": {
+      "path": "carbon-components-svelte/src/LocalStorage/LocalStorage.svelte"
+    },
+    "Modal": {
+      "path": "carbon-components-svelte/src/Modal/Modal.svelte"
+    },
+    "ModalBody": {
+      "path": "carbon-components-svelte/src/ComposedModal/ModalBody.svelte"
+    },
+    "ModalFooter": {
+      "path": "carbon-components-svelte/src/ComposedModal/ModalFooter.svelte"
+    },
+    "ModalHeader": {
+      "path": "carbon-components-svelte/src/ComposedModal/ModalHeader.svelte"
+    },
+    "MultiSelect": {
+      "path": "carbon-components-svelte/src/MultiSelect/MultiSelect.svelte"
+    },
+    "NotificationActionButton": {
+      "path": "carbon-components-svelte/src/Notification/NotificationActionButton.svelte"
+    },
+    "NotificationButton": {
+      "path": "carbon-components-svelte/src/Notification/NotificationButton.svelte"
+    },
+    "NotificationIcon": {
+      "path": "carbon-components-svelte/src/Notification/NotificationIcon.svelte"
+    },
+    "NotificationTextDetails": {
+      "path": "carbon-components-svelte/src/Notification/NotificationTextDetails.svelte"
+    },
+    "NumberInput": {
+      "path": "carbon-components-svelte/src/NumberInput/NumberInput.svelte"
+    },
+    "NumberInputSkeleton": {
+      "path": "carbon-components-svelte/src/NumberInput/NumberInputSkeleton.svelte"
+    },
+    "OrderedList": {
+      "path": "carbon-components-svelte/src/OrderedList/OrderedList.svelte"
+    },
+    "OutboundLink": {
+      "path": "carbon-components-svelte/src/Link/OutboundLink.svelte"
+    },
+    "OverflowMenu": {
+      "path": "carbon-components-svelte/src/OverflowMenu/OverflowMenu.svelte"
+    },
+    "OverflowMenuItem": {
+      "path": "carbon-components-svelte/src/OverflowMenu/OverflowMenuItem.svelte"
+    },
+    "Pagination": {
+      "path": "carbon-components-svelte/src/Pagination/Pagination.svelte"
+    },
+    "PaginationNav": {
+      "path": "carbon-components-svelte/src/PaginationNav/PaginationNav.svelte"
+    },
+    "PaginationSkeleton": {
+      "path": "carbon-components-svelte/src/Pagination/PaginationSkeleton.svelte"
+    },
+    "PasswordInput": {
+      "path": "carbon-components-svelte/src/TextInput/PasswordInput.svelte"
+    },
+    "Popover": {
+      "path": "carbon-components-svelte/src/Popover/Popover.svelte"
+    },
+    "ProgressBar": {
+      "path": "carbon-components-svelte/src/ProgressBar/ProgressBar.svelte"
+    },
+    "ProgressIndicator": {
+      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressIndicator.svelte"
+    },
+    "ProgressIndicatorSkeleton": {
+      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte"
+    },
+    "ProgressStep": {
+      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressStep.svelte"
+    },
+    "RadioButton": {
+      "path": "carbon-components-svelte/src/RadioButton/RadioButton.svelte"
+    },
+    "RadioButtonGroup": {
+      "path": "carbon-components-svelte/src/RadioButtonGroup/RadioButtonGroup.svelte"
+    },
+    "RadioButtonSkeleton": {
+      "path": "carbon-components-svelte/src/RadioButton/RadioButtonSkeleton.svelte"
+    },
+    "RadioTile": {
+      "path": "carbon-components-svelte/src/Tile/RadioTile.svelte"
+    },
+    "RecursiveList": {
+      "path": "carbon-components-svelte/src/RecursiveList/RecursiveList.svelte"
+    },
+    "Row": {
+      "path": "carbon-components-svelte/src/Grid/Row.svelte"
+    },
+    "Search": {
+      "path": "carbon-components-svelte/src/Search/Search.svelte"
+    },
+    "SearchSkeleton": {
+      "path": "carbon-components-svelte/src/Search/SearchSkeleton.svelte"
+    },
+    "Select": {
+      "path": "carbon-components-svelte/src/Select/Select.svelte"
+    },
+    "SelectItem": {
+      "path": "carbon-components-svelte/src/Select/SelectItem.svelte"
+    },
+    "SelectItemGroup": {
+      "path": "carbon-components-svelte/src/Select/SelectItemGroup.svelte"
+    },
+    "SelectSkeleton": {
+      "path": "carbon-components-svelte/src/Select/SelectSkeleton.svelte"
+    },
+    "SelectableTile": {
+      "path": "carbon-components-svelte/src/Tile/SelectableTile.svelte"
+    },
+    "SideNav": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNav.svelte"
+    },
+    "SideNavDivider": {
+      "path": "carbon-components-svelte/src/UIShell/SideNavDivider.svelte"
+    },
+    "SideNavItems": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavItems.svelte"
+    },
+    "SideNavLink": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavLink.svelte"
+    },
+    "SideNavMenu": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavMenu.svelte"
+    },
+    "SideNavMenuItem": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavMenuItem.svelte"
+    },
+    "SkeletonPlaceholder": {
+      "path": "carbon-components-svelte/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte"
+    },
+    "SkeletonText": {
+      "path": "carbon-components-svelte/src/SkeletonText/SkeletonText.svelte"
+    },
+    "SkipToContent": {
+      "path": "carbon-components-svelte/src/UIShell/SkipToContent.svelte"
+    },
+    "Slider": {
+      "path": "carbon-components-svelte/src/Slider/Slider.svelte"
+    },
+    "SliderSkeleton": {
+      "path": "carbon-components-svelte/src/Slider/SliderSkeleton.svelte"
+    },
+    "StructuredList": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredList.svelte"
+    },
+    "StructuredListBody": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListBody.svelte"
+    },
+    "StructuredListCell": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListCell.svelte"
+    },
+    "StructuredListHead": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListHead.svelte"
+    },
+    "StructuredListInput": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListInput.svelte"
+    },
+    "StructuredListRow": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListRow.svelte"
+    },
+    "StructuredListSkeleton": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListSkeleton.svelte"
+    },
+    "Switch": {
+      "path": "carbon-components-svelte/src/ContentSwitcher/Switch.svelte"
+    },
+    "Tab": {
+      "path": "carbon-components-svelte/src/Tabs/Tab.svelte"
+    },
+    "TabContent": {
+      "path": "carbon-components-svelte/src/Tabs/TabContent.svelte"
     },
     "Table": {
       "path": "carbon-components-svelte/src/DataTable/Table.svelte"
@@ -133,6 +425,60 @@ export const components = {
     "TableRow": {
       "path": "carbon-components-svelte/src/DataTable/TableRow.svelte"
     },
+    "Tabs": {
+      "path": "carbon-components-svelte/src/Tabs/Tabs.svelte"
+    },
+    "TabsSkeleton": {
+      "path": "carbon-components-svelte/src/Tabs/TabsSkeleton.svelte"
+    },
+    "Tag": {
+      "path": "carbon-components-svelte/src/Tag/Tag.svelte"
+    },
+    "TagSkeleton": {
+      "path": "carbon-components-svelte/src/Tag/TagSkeleton.svelte"
+    },
+    "TextArea": {
+      "path": "carbon-components-svelte/src/TextArea/TextArea.svelte"
+    },
+    "TextAreaSkeleton": {
+      "path": "carbon-components-svelte/src/TextArea/TextAreaSkeleton.svelte"
+    },
+    "TextInput": {
+      "path": "carbon-components-svelte/src/TextInput/TextInput.svelte"
+    },
+    "TextInputSkeleton": {
+      "path": "carbon-components-svelte/src/TextInput/TextInputSkeleton.svelte"
+    },
+    "Theme": {
+      "path": "carbon-components-svelte/src/Theme/Theme.svelte"
+    },
+    "Tile": {
+      "path": "carbon-components-svelte/src/Tile/Tile.svelte"
+    },
+    "TileGroup": {
+      "path": "carbon-components-svelte/src/Tile/TileGroup.svelte"
+    },
+    "TimePicker": {
+      "path": "carbon-components-svelte/src/TimePicker/TimePicker.svelte"
+    },
+    "TimePickerSelect": {
+      "path": "carbon-components-svelte/src/TimePicker/TimePickerSelect.svelte"
+    },
+    "ToastNotification": {
+      "path": "carbon-components-svelte/src/Notification/ToastNotification.svelte"
+    },
+    "Toggle": {
+      "path": "carbon-components-svelte/src/Toggle/Toggle.svelte"
+    },
+    "ToggleSkeleton": {
+      "path": "carbon-components-svelte/src/Toggle/ToggleSkeleton.svelte"
+    },
+    "ToggleSmall": {
+      "path": "carbon-components-svelte/src/ToggleSmall/ToggleSmall.svelte"
+    },
+    "ToggleSmallSkeleton": {
+      "path": "carbon-components-svelte/src/ToggleSmall/ToggleSmallSkeleton.svelte"
+    },
     "Toolbar": {
       "path": "carbon-components-svelte/src/DataTable/Toolbar.svelte"
     },
@@ -151,326 +497,11 @@ export const components = {
     "ToolbarSearch": {
       "path": "carbon-components-svelte/src/DataTable/ToolbarSearch.svelte"
     },
-    "Dropdown": {
-      "path": "carbon-components-svelte/src/Dropdown/Dropdown.svelte"
-    },
-    "DataTableSkeleton": {
-      "path": "carbon-components-svelte/src/DataTable/DataTableSkeleton.svelte"
-    },
-    "DropdownSkeleton": {
-      "path": "carbon-components-svelte/src/Dropdown/DropdownSkeleton.svelte"
-    },
-    "DatePickerInput": {
-      "path": "carbon-components-svelte/src/DatePicker/DatePickerInput.svelte"
-    },
-    "DatePicker": {
-      "path": "carbon-components-svelte/src/DatePicker/DatePicker.svelte"
-    },
-    "createCalendar": {
-      "path": "carbon-components-svelte/src/DatePicker/createCalendar.js"
-    },
-    "DatePickerSkeleton": {
-      "path": "carbon-components-svelte/src/DatePicker/DatePickerSkeleton.svelte"
-    },
-    "FileUploader": {
-      "path": "carbon-components-svelte/src/FileUploader/FileUploader.svelte"
-    },
-    "FileUploaderDropContainer": {
-      "path": "carbon-components-svelte/src/FileUploader/FileUploaderDropContainer.svelte"
-    },
-    "FileUploaderButton": {
-      "path": "carbon-components-svelte/src/FileUploader/FileUploaderButton.svelte"
-    },
-    "FileUploaderItem": {
-      "path": "carbon-components-svelte/src/FileUploader/FileUploaderItem.svelte"
-    },
-    "FileUploaderSkeleton": {
-      "path": "carbon-components-svelte/src/FileUploader/FileUploaderSkeleton.svelte"
-    },
-    "Filename": {
-      "path": "carbon-components-svelte/src/FileUploader/Filename.svelte"
-    },
-    "Form": {
-      "path": "carbon-components-svelte/src/Form/Form.svelte"
-    },
-    "FluidForm": {
-      "path": "carbon-components-svelte/src/FluidForm/FluidForm.svelte"
-    },
-    "FormGroup": {
-      "path": "carbon-components-svelte/src/FormGroup/FormGroup.svelte"
-    },
-    "FormItem": {
-      "path": "carbon-components-svelte/src/FormItem/FormItem.svelte"
-    },
-    "Column": {
-      "path": "carbon-components-svelte/src/Grid/Column.svelte"
-    },
-    "Grid": {
-      "path": "carbon-components-svelte/src/Grid/Grid.svelte"
-    },
-    "Row": {
-      "path": "carbon-components-svelte/src/Grid/Row.svelte"
-    },
-    "InlineLoading": {
-      "path": "carbon-components-svelte/src/InlineLoading/InlineLoading.svelte"
-    },
-    "FormLabel": {
-      "path": "carbon-components-svelte/src/FormLabel/FormLabel.svelte"
-    },
-    "Icon": {
-      "path": "carbon-components-svelte/src/Icon/Icon.svelte"
-    },
-    "IconSkeleton": {
-      "path": "carbon-components-svelte/src/Icon/IconSkeleton.svelte"
-    },
-    "Link": {
-      "path": "carbon-components-svelte/src/Link/Link.svelte"
-    },
-    "OutboundLink": {
-      "path": "carbon-components-svelte/src/Link/OutboundLink.svelte"
-    },
-    "ImageLoader": {
-      "path": "carbon-components-svelte/src/ImageLoader/ImageLoader.svelte"
-    },
-    "LocalStorage": {
-      "path": "carbon-components-svelte/src/LocalStorage/LocalStorage.svelte"
-    },
-    "ListBoxField": {
-      "path": "carbon-components-svelte/src/ListBox/ListBoxField.svelte"
-    },
-    "ListBoxMenu": {
-      "path": "carbon-components-svelte/src/ListBox/ListBoxMenu.svelte"
-    },
-    "ListBoxMenuIcon": {
-      "path": "carbon-components-svelte/src/ListBox/ListBoxMenuIcon.svelte"
-    },
-    "ListBoxSelection": {
-      "path": "carbon-components-svelte/src/ListBox/ListBoxSelection.svelte"
-    },
-    "ListBoxMenuItem": {
-      "path": "carbon-components-svelte/src/ListBox/ListBoxMenuItem.svelte"
-    },
-    "ListItem": {
-      "path": "carbon-components-svelte/src/ListItem/ListItem.svelte"
-    },
-    "Loading": {
-      "path": "carbon-components-svelte/src/Loading/Loading.svelte"
-    },
-    "Modal": {
-      "path": "carbon-components-svelte/src/Modal/Modal.svelte"
-    },
-    "ListBox": {
-      "path": "carbon-components-svelte/src/ListBox/ListBox.svelte"
-    },
-    "NumberInput": {
-      "path": "carbon-components-svelte/src/NumberInput/NumberInput.svelte"
-    },
-    "NumberInputSkeleton": {
-      "path": "carbon-components-svelte/src/NumberInput/NumberInputSkeleton.svelte"
-    },
-    "MultiSelect": {
-      "path": "carbon-components-svelte/src/MultiSelect/MultiSelect.svelte"
-    },
-    "InlineNotification": {
-      "path": "carbon-components-svelte/src/Notification/InlineNotification.svelte"
-    },
-    "NotificationActionButton": {
-      "path": "carbon-components-svelte/src/Notification/NotificationActionButton.svelte"
-    },
-    "NotificationButton": {
-      "path": "carbon-components-svelte/src/Notification/NotificationButton.svelte"
-    },
-    "NotificationIcon": {
-      "path": "carbon-components-svelte/src/Notification/NotificationIcon.svelte"
-    },
-    "NotificationTextDetails": {
-      "path": "carbon-components-svelte/src/Notification/NotificationTextDetails.svelte"
-    },
-    "ToastNotification": {
-      "path": "carbon-components-svelte/src/Notification/ToastNotification.svelte"
-    },
-    "OrderedList": {
-      "path": "carbon-components-svelte/src/OrderedList/OrderedList.svelte"
-    },
-    "PaginationSkeleton": {
-      "path": "carbon-components-svelte/src/Pagination/PaginationSkeleton.svelte"
-    },
-    "Pagination": {
-      "path": "carbon-components-svelte/src/Pagination/Pagination.svelte"
-    },
-    "OverflowMenuItem": {
-      "path": "carbon-components-svelte/src/OverflowMenu/OverflowMenuItem.svelte"
-    },
-    "OverflowMenu": {
-      "path": "carbon-components-svelte/src/OverflowMenu/OverflowMenu.svelte"
-    },
-    "PaginationItem": {
-      "path": "carbon-components-svelte/src/PaginationNav/PaginationItem.svelte"
-    },
-    "PaginationNav": {
-      "path": "carbon-components-svelte/src/PaginationNav/PaginationNav.svelte"
-    },
-    "PaginationOverflow": {
-      "path": "carbon-components-svelte/src/PaginationNav/PaginationOverflow.svelte"
-    },
-    "ProgressBar": {
-      "path": "carbon-components-svelte/src/ProgressBar/ProgressBar.svelte"
-    },
-    "Popover": {
-      "path": "carbon-components-svelte/src/Popover/Popover.svelte"
-    },
-    "RadioButton": {
-      "path": "carbon-components-svelte/src/RadioButton/RadioButton.svelte"
-    },
-    "RadioButtonSkeleton": {
-      "path": "carbon-components-svelte/src/RadioButton/RadioButtonSkeleton.svelte"
-    },
-    "Search": {
-      "path": "carbon-components-svelte/src/Search/Search.svelte"
-    },
-    "SearchSkeleton": {
-      "path": "carbon-components-svelte/src/Search/SearchSkeleton.svelte"
-    },
-    "ProgressIndicatorSkeleton": {
-      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte"
-    },
-    "ProgressIndicator": {
-      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressIndicator.svelte"
-    },
-    "RadioButtonGroup": {
-      "path": "carbon-components-svelte/src/RadioButtonGroup/RadioButtonGroup.svelte"
-    },
-    "ProgressStep": {
-      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressStep.svelte"
-    },
-    "RecursiveList": {
-      "path": "carbon-components-svelte/src/RecursiveList/RecursiveList.svelte"
-    },
-    "RecursiveListItem": {
-      "path": "carbon-components-svelte/src/RecursiveList/RecursiveListItem.svelte"
-    },
-    "Select": {
-      "path": "carbon-components-svelte/src/Select/Select.svelte"
-    },
-    "SelectItem": {
-      "path": "carbon-components-svelte/src/Select/SelectItem.svelte"
-    },
-    "SelectItemGroup": {
-      "path": "carbon-components-svelte/src/Select/SelectItemGroup.svelte"
-    },
-    "SelectSkeleton": {
-      "path": "carbon-components-svelte/src/Select/SelectSkeleton.svelte"
-    },
-    "SkeletonPlaceholder": {
-      "path": "carbon-components-svelte/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte"
-    },
-    "SkeletonText": {
-      "path": "carbon-components-svelte/src/SkeletonText/SkeletonText.svelte"
-    },
-    "Slider": {
-      "path": "carbon-components-svelte/src/Slider/Slider.svelte"
-    },
-    "SliderSkeleton": {
-      "path": "carbon-components-svelte/src/Slider/SliderSkeleton.svelte"
-    },
-    "Tag": {
-      "path": "carbon-components-svelte/src/Tag/Tag.svelte"
-    },
-    "TagSkeleton": {
-      "path": "carbon-components-svelte/src/Tag/TagSkeleton.svelte"
-    },
-    "Tab": {
-      "path": "carbon-components-svelte/src/Tabs/Tab.svelte"
-    },
-    "TabContent": {
-      "path": "carbon-components-svelte/src/Tabs/TabContent.svelte"
-    },
-    "TabsSkeleton": {
-      "path": "carbon-components-svelte/src/Tabs/TabsSkeleton.svelte"
-    },
-    "Tabs": {
-      "path": "carbon-components-svelte/src/Tabs/Tabs.svelte"
-    },
-    "TextArea": {
-      "path": "carbon-components-svelte/src/TextArea/TextArea.svelte"
-    },
-    "TextAreaSkeleton": {
-      "path": "carbon-components-svelte/src/TextArea/TextAreaSkeleton.svelte"
-    },
-    "StructuredList": {
-      "path": "carbon-components-svelte/src/StructuredList/StructuredList.svelte"
-    },
-    "StructuredListBody": {
-      "path": "carbon-components-svelte/src/StructuredList/StructuredListBody.svelte"
-    },
-    "StructuredListCell": {
-      "path": "carbon-components-svelte/src/StructuredList/StructuredListCell.svelte"
-    },
-    "StructuredListInput": {
-      "path": "carbon-components-svelte/src/StructuredList/StructuredListInput.svelte"
-    },
-    "StructuredListRow": {
-      "path": "carbon-components-svelte/src/StructuredList/StructuredListRow.svelte"
-    },
-    "StructuredListHead": {
-      "path": "carbon-components-svelte/src/StructuredList/StructuredListHead.svelte"
-    },
-    "StructuredListSkeleton": {
-      "path": "carbon-components-svelte/src/StructuredList/StructuredListSkeleton.svelte"
-    },
-    "TextInput": {
-      "path": "carbon-components-svelte/src/TextInput/TextInput.svelte"
-    },
-    "TimePicker": {
-      "path": "carbon-components-svelte/src/TimePicker/TimePicker.svelte"
-    },
-    "TextInputSkeleton": {
-      "path": "carbon-components-svelte/src/TextInput/TextInputSkeleton.svelte"
-    },
-    "PasswordInput": {
-      "path": "carbon-components-svelte/src/TextInput/PasswordInput.svelte"
-    },
-    "TimePickerSelect": {
-      "path": "carbon-components-svelte/src/TimePicker/TimePickerSelect.svelte"
-    },
-    "Toggle": {
-      "path": "carbon-components-svelte/src/Toggle/Toggle.svelte"
-    },
-    "ToggleSkeleton": {
-      "path": "carbon-components-svelte/src/Toggle/ToggleSkeleton.svelte"
-    },
-    "ClickableTile": {
-      "path": "carbon-components-svelte/src/Tile/ClickableTile.svelte"
-    },
-    "ExpandableTile": {
-      "path": "carbon-components-svelte/src/Tile/ExpandableTile.svelte"
-    },
-    "RadioTile": {
-      "path": "carbon-components-svelte/src/Tile/RadioTile.svelte"
-    },
-    "SelectableTile": {
-      "path": "carbon-components-svelte/src/Tile/SelectableTile.svelte"
-    },
-    "Tile": {
-      "path": "carbon-components-svelte/src/Tile/Tile.svelte"
-    },
-    "TileGroup": {
-      "path": "carbon-components-svelte/src/Tile/TileGroup.svelte"
-    },
-    "Theme": {
-      "path": "carbon-components-svelte/src/Theme/Theme.svelte"
+    "Tooltip": {
+      "path": "carbon-components-svelte/src/Tooltip/Tooltip.svelte"
     },
     "TooltipDefinition": {
       "path": "carbon-components-svelte/src/TooltipDefinition/TooltipDefinition.svelte"
-    },
-    "ToggleSmall": {
-      "path": "carbon-components-svelte/src/ToggleSmall/ToggleSmall.svelte"
-    },
-    "ToggleSmallSkeleton": {
-      "path": "carbon-components-svelte/src/ToggleSmall/ToggleSmallSkeleton.svelte"
-    },
-    "Tooltip": {
-      "path": "carbon-components-svelte/src/Tooltip/Tooltip.svelte"
     },
     "TooltipFooter": {
       "path": "carbon-components-svelte/src/Tooltip/TooltipFooter.svelte"
@@ -478,215 +509,14 @@ export const components = {
     "TooltipIcon": {
       "path": "carbon-components-svelte/src/TooltipIcon/TooltipIcon.svelte"
     },
-    "Truncate": {
-      "path": "carbon-components-svelte/src/Truncate/Truncate.svelte"
-    },
     "TreeView": {
       "path": "carbon-components-svelte/src/TreeView/TreeView.svelte"
     },
-    "TreeViewNodeList": {
-      "path": "carbon-components-svelte/src/TreeView/TreeViewNodeList.svelte"
-    },
-    "TreeViewNode": {
-      "path": "carbon-components-svelte/src/TreeView/TreeViewNode.svelte"
+    "Truncate": {
+      "path": "carbon-components-svelte/src/Truncate/Truncate.svelte"
     },
     "UnorderedList": {
       "path": "carbon-components-svelte/src/UnorderedList/UnorderedList.svelte"
-    },
-    "Content": {
-      "path": "carbon-components-svelte/src/UIShell/Content.svelte"
-    },
-    "HeaderGlobalAction": {
-      "path": "carbon-components-svelte/src/UIShell/HeaderGlobalAction.svelte"
-    },
-    "HeaderSearch": {
-      "path": "carbon-components-svelte/src/UIShell/HeaderSearch.svelte"
-    },
-    "SkipToContent": {
-      "path": "carbon-components-svelte/src/UIShell/SkipToContent.svelte"
-    },
-    "SideNavDivider": {
-      "path": "carbon-components-svelte/src/UIShell/SideNavDivider.svelte"
-    },
-    "navStore": {
-      "path": "carbon-components-svelte/src/UIShell/navStore.js"
-    },
-    "searchStore": {
-      "path": "carbon-components-svelte/src/UIShell/searchStore.js"
-    },
-    "Add16": {
-      "path": "carbon-components-svelte/src/icons/Add16.svelte"
-    },
-    "AppSwitcher20": {
-      "path": "carbon-components-svelte/src/icons/AppSwitcher20.svelte"
-    },
-    "Calendar16": {
-      "path": "carbon-components-svelte/src/icons/Calendar16.svelte"
-    },
-    "ArrowUp20": {
-      "path": "carbon-components-svelte/src/icons/ArrowUp20.svelte"
-    },
-    "CaretDown16": {
-      "path": "carbon-components-svelte/src/icons/CaretDown16.svelte"
-    },
-    "ArrowsVertical20": {
-      "path": "carbon-components-svelte/src/icons/ArrowsVertical20.svelte"
-    },
-    "CaretRight16": {
-      "path": "carbon-components-svelte/src/icons/CaretRight16.svelte"
-    },
-    "CaretLeft16": {
-      "path": "carbon-components-svelte/src/icons/CaretLeft16.svelte"
-    },
-    "Checkmark16": {
-      "path": "carbon-components-svelte/src/icons/Checkmark16.svelte"
-    },
-    "CheckmarkFilled16": {
-      "path": "carbon-components-svelte/src/icons/CheckmarkFilled16.svelte"
-    },
-    "CheckmarkFilled20": {
-      "path": "carbon-components-svelte/src/icons/CheckmarkFilled20.svelte"
-    },
-    "CheckmarkOutline16": {
-      "path": "carbon-components-svelte/src/icons/CheckmarkOutline16.svelte"
-    },
-    "ChevronDown16": {
-      "path": "carbon-components-svelte/src/icons/ChevronDown16.svelte"
-    },
-    "ChevronDownGlyph": {
-      "path": "carbon-components-svelte/src/icons/ChevronDownGlyph.svelte"
-    },
-    "ChevronRight16": {
-      "path": "carbon-components-svelte/src/icons/ChevronRight16.svelte"
-    },
-    "CircleDash16": {
-      "path": "carbon-components-svelte/src/icons/CircleDash16.svelte"
-    },
-    "Close20": {
-      "path": "carbon-components-svelte/src/icons/Close20.svelte"
-    },
-    "Copy16": {
-      "path": "carbon-components-svelte/src/icons/Copy16.svelte"
-    },
-    "Close16": {
-      "path": "carbon-components-svelte/src/icons/Close16.svelte"
-    },
-    "ErrorFilled20": {
-      "path": "carbon-components-svelte/src/icons/ErrorFilled20.svelte"
-    },
-    "ErrorFilled16": {
-      "path": "carbon-components-svelte/src/icons/ErrorFilled16.svelte"
-    },
-    "Incomplete16": {
-      "path": "carbon-components-svelte/src/icons/Incomplete16.svelte"
-    },
-    "EditOff16": {
-      "path": "carbon-components-svelte/src/icons/EditOff16.svelte"
-    },
-    "Information16": {
-      "path": "carbon-components-svelte/src/icons/Information16.svelte"
-    },
-    "InformationFilled20": {
-      "path": "carbon-components-svelte/src/icons/InformationFilled20.svelte"
-    },
-    "InformationSquareFilled20": {
-      "path": "carbon-components-svelte/src/icons/InformationSquareFilled20.svelte"
-    },
-    "Launch16": {
-      "path": "carbon-components-svelte/src/icons/Launch16.svelte"
-    },
-    "Menu20": {
-      "path": "carbon-components-svelte/src/icons/Menu20.svelte"
-    },
-    "OverflowMenuHorizontal16": {
-      "path": "carbon-components-svelte/src/icons/OverflowMenuHorizontal16.svelte"
-    },
-    "Search20": {
-      "path": "carbon-components-svelte/src/icons/Search20.svelte"
-    },
-    "Settings16": {
-      "path": "carbon-components-svelte/src/icons/Settings16.svelte"
-    },
-    "OverflowMenuVertical16": {
-      "path": "carbon-components-svelte/src/icons/OverflowMenuVertical16.svelte"
-    },
-    "Search16": {
-      "path": "carbon-components-svelte/src/icons/Search16.svelte"
-    },
-    "Subtract16": {
-      "path": "carbon-components-svelte/src/icons/Subtract16.svelte"
-    },
-    "View16": {
-      "path": "carbon-components-svelte/src/icons/View16.svelte"
-    },
-    "ViewOff16": {
-      "path": "carbon-components-svelte/src/icons/ViewOff16.svelte"
-    },
-    "Warning16": {
-      "path": "carbon-components-svelte/src/icons/Warning16.svelte"
-    },
-    "WarningAltFilled16": {
-      "path": "carbon-components-svelte/src/icons/WarningAltFilled16.svelte"
-    },
-    "WarningAltFilled20": {
-      "path": "carbon-components-svelte/src/icons/WarningAltFilled20.svelte"
-    },
-    "WarningFilled16": {
-      "path": "carbon-components-svelte/src/icons/WarningFilled16.svelte"
-    },
-    "WarningFilled20": {
-      "path": "carbon-components-svelte/src/icons/WarningFilled20.svelte"
-    },
-    "HamburgerMenu": {
-      "path": "carbon-components-svelte/src/UIShell/SideNav/HamburgerMenu.svelte"
-    },
-    "SideNav": {
-      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNav.svelte"
-    },
-    "SideNavMenu": {
-      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavMenu.svelte"
-    },
-    "SideNavItems": {
-      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavItems.svelte"
-    },
-    "SideNavMenuItem": {
-      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavMenuItem.svelte"
-    },
-    "SideNavLink": {
-      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavLink.svelte"
-    },
-    "Header": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/Header.svelte"
-    },
-    "HeaderAction": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderAction.svelte"
-    },
-    "HeaderActionLink": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderActionLink.svelte"
-    },
-    "HeaderActionSearch": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderActionSearch.svelte"
-    },
-    "HeaderNavItem": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNavItem.svelte"
-    },
-    "HeaderNavMenu": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNavMenu.svelte"
-    },
-    "HeaderNav": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNav.svelte"
-    },
-    "HeaderPanelDivider": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelDivider.svelte"
-    },
-    "HeaderPanelLinks": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelLinks.svelte"
-    },
-    "HeaderPanelLink": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelLink.svelte"
-    },
-    "HeaderUtilities": {
-      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderUtilities.svelte"
     }
   }
 }

--- a/src/carbon-components-svelte.js
+++ b/src/carbon-components-svelte.js
@@ -1,0 +1,692 @@
+export const components = {
+  "metadata": {
+    "package": "carbon-components-svelte",
+    "version": "0.62.0"
+  },
+  "components": {
+    "index": {
+      "path": "carbon-components-svelte/src/UIShell/index.js"
+    },
+    "Accordion": {
+      "path": "carbon-components-svelte/src/Accordion/Accordion.svelte"
+    },
+    "AccordionItem": {
+      "path": "carbon-components-svelte/src/Accordion/AccordionItem.svelte"
+    },
+    "AccordionSkeleton": {
+      "path": "carbon-components-svelte/src/Accordion/AccordionSkeleton.svelte"
+    },
+    "Breadcrumb": {
+      "path": "carbon-components-svelte/src/Breadcrumb/Breadcrumb.svelte"
+    },
+    "BreadcrumbSkeleton": {
+      "path": "carbon-components-svelte/src/Breadcrumb/BreadcrumbSkeleton.svelte"
+    },
+    "BreadcrumbItem": {
+      "path": "carbon-components-svelte/src/Breadcrumb/BreadcrumbItem.svelte"
+    },
+    "Breakpoint": {
+      "path": "carbon-components-svelte/src/Breakpoint/Breakpoint.svelte"
+    },
+    "breakpointObserver.d": {
+      "path": "carbon-components-svelte/src/Breakpoint/breakpointObserver.d.ts"
+    },
+    "breakpointObserver": {
+      "path": "carbon-components-svelte/src/Breakpoint/breakpointObserver.js"
+    },
+    "breakpoints.d": {
+      "path": "carbon-components-svelte/src/Breakpoint/breakpoints.d.ts"
+    },
+    "breakpoints": {
+      "path": "carbon-components-svelte/src/Breakpoint/breakpoints.js"
+    },
+    "index.d": {
+      "path": "carbon-components-svelte/src/Breakpoint/index.d.ts"
+    },
+    "AspectRatio": {
+      "path": "carbon-components-svelte/src/AspectRatio/AspectRatio.svelte"
+    },
+    "Button": {
+      "path": "carbon-components-svelte/src/Button/Button.svelte"
+    },
+    "ButtonSet": {
+      "path": "carbon-components-svelte/src/Button/ButtonSet.svelte"
+    },
+    "ButtonSkeleton": {
+      "path": "carbon-components-svelte/src/Button/ButtonSkeleton.svelte"
+    },
+    "CodeSnippet": {
+      "path": "carbon-components-svelte/src/CodeSnippet/CodeSnippet.svelte"
+    },
+    "CodeSnippetSkeleton": {
+      "path": "carbon-components-svelte/src/CodeSnippet/CodeSnippetSkeleton.svelte"
+    },
+    "Checkbox": {
+      "path": "carbon-components-svelte/src/Checkbox/Checkbox.svelte"
+    },
+    "InlineCheckbox": {
+      "path": "carbon-components-svelte/src/Checkbox/InlineCheckbox.svelte"
+    },
+    "CheckboxSkeleton": {
+      "path": "carbon-components-svelte/src/Checkbox/CheckboxSkeleton.svelte"
+    },
+    "ComboBox": {
+      "path": "carbon-components-svelte/src/ComboBox/ComboBox.svelte"
+    },
+    "ComposedModal": {
+      "path": "carbon-components-svelte/src/ComposedModal/ComposedModal.svelte"
+    },
+    "ModalFooter": {
+      "path": "carbon-components-svelte/src/ComposedModal/ModalFooter.svelte"
+    },
+    "ModalHeader": {
+      "path": "carbon-components-svelte/src/ComposedModal/ModalHeader.svelte"
+    },
+    "CopyButton": {
+      "path": "carbon-components-svelte/src/CopyButton/CopyButton.svelte"
+    },
+    "ModalBody": {
+      "path": "carbon-components-svelte/src/ComposedModal/ModalBody.svelte"
+    },
+    "ContentSwitcher": {
+      "path": "carbon-components-svelte/src/ContentSwitcher/ContentSwitcher.svelte"
+    },
+    "Switch": {
+      "path": "carbon-components-svelte/src/ContentSwitcher/Switch.svelte"
+    },
+    "ContextMenuDivider": {
+      "path": "carbon-components-svelte/src/ContextMenu/ContextMenuDivider.svelte"
+    },
+    "ContextMenuGroup": {
+      "path": "carbon-components-svelte/src/ContextMenu/ContextMenuGroup.svelte"
+    },
+    "ContextMenu": {
+      "path": "carbon-components-svelte/src/ContextMenu/ContextMenu.svelte"
+    },
+    "ContextMenuRadioGroup": {
+      "path": "carbon-components-svelte/src/ContextMenu/ContextMenuRadioGroup.svelte"
+    },
+    "ContextMenuOption": {
+      "path": "carbon-components-svelte/src/ContextMenu/ContextMenuOption.svelte"
+    },
+    "DataTable": {
+      "path": "carbon-components-svelte/src/DataTable/DataTable.svelte"
+    },
+    "Table": {
+      "path": "carbon-components-svelte/src/DataTable/Table.svelte"
+    },
+    "TableBody": {
+      "path": "carbon-components-svelte/src/DataTable/TableBody.svelte"
+    },
+    "TableCell": {
+      "path": "carbon-components-svelte/src/DataTable/TableCell.svelte"
+    },
+    "TableContainer": {
+      "path": "carbon-components-svelte/src/DataTable/TableContainer.svelte"
+    },
+    "TableHead": {
+      "path": "carbon-components-svelte/src/DataTable/TableHead.svelte"
+    },
+    "TableHeader": {
+      "path": "carbon-components-svelte/src/DataTable/TableHeader.svelte"
+    },
+    "TableRow": {
+      "path": "carbon-components-svelte/src/DataTable/TableRow.svelte"
+    },
+    "Toolbar": {
+      "path": "carbon-components-svelte/src/DataTable/Toolbar.svelte"
+    },
+    "ToolbarBatchActions": {
+      "path": "carbon-components-svelte/src/DataTable/ToolbarBatchActions.svelte"
+    },
+    "ToolbarContent": {
+      "path": "carbon-components-svelte/src/DataTable/ToolbarContent.svelte"
+    },
+    "ToolbarMenu": {
+      "path": "carbon-components-svelte/src/DataTable/ToolbarMenu.svelte"
+    },
+    "ToolbarMenuItem": {
+      "path": "carbon-components-svelte/src/DataTable/ToolbarMenuItem.svelte"
+    },
+    "ToolbarSearch": {
+      "path": "carbon-components-svelte/src/DataTable/ToolbarSearch.svelte"
+    },
+    "Dropdown": {
+      "path": "carbon-components-svelte/src/Dropdown/Dropdown.svelte"
+    },
+    "DataTableSkeleton": {
+      "path": "carbon-components-svelte/src/DataTable/DataTableSkeleton.svelte"
+    },
+    "DropdownSkeleton": {
+      "path": "carbon-components-svelte/src/Dropdown/DropdownSkeleton.svelte"
+    },
+    "DatePickerInput": {
+      "path": "carbon-components-svelte/src/DatePicker/DatePickerInput.svelte"
+    },
+    "DatePicker": {
+      "path": "carbon-components-svelte/src/DatePicker/DatePicker.svelte"
+    },
+    "createCalendar": {
+      "path": "carbon-components-svelte/src/DatePicker/createCalendar.js"
+    },
+    "DatePickerSkeleton": {
+      "path": "carbon-components-svelte/src/DatePicker/DatePickerSkeleton.svelte"
+    },
+    "FileUploader": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploader.svelte"
+    },
+    "FileUploaderDropContainer": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderDropContainer.svelte"
+    },
+    "FileUploaderButton": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderButton.svelte"
+    },
+    "FileUploaderItem": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderItem.svelte"
+    },
+    "FileUploaderSkeleton": {
+      "path": "carbon-components-svelte/src/FileUploader/FileUploaderSkeleton.svelte"
+    },
+    "Filename": {
+      "path": "carbon-components-svelte/src/FileUploader/Filename.svelte"
+    },
+    "Form": {
+      "path": "carbon-components-svelte/src/Form/Form.svelte"
+    },
+    "FluidForm": {
+      "path": "carbon-components-svelte/src/FluidForm/FluidForm.svelte"
+    },
+    "FormGroup": {
+      "path": "carbon-components-svelte/src/FormGroup/FormGroup.svelte"
+    },
+    "FormItem": {
+      "path": "carbon-components-svelte/src/FormItem/FormItem.svelte"
+    },
+    "Column": {
+      "path": "carbon-components-svelte/src/Grid/Column.svelte"
+    },
+    "Grid": {
+      "path": "carbon-components-svelte/src/Grid/Grid.svelte"
+    },
+    "Row": {
+      "path": "carbon-components-svelte/src/Grid/Row.svelte"
+    },
+    "InlineLoading": {
+      "path": "carbon-components-svelte/src/InlineLoading/InlineLoading.svelte"
+    },
+    "FormLabel": {
+      "path": "carbon-components-svelte/src/FormLabel/FormLabel.svelte"
+    },
+    "Icon": {
+      "path": "carbon-components-svelte/src/Icon/Icon.svelte"
+    },
+    "IconSkeleton": {
+      "path": "carbon-components-svelte/src/Icon/IconSkeleton.svelte"
+    },
+    "Link": {
+      "path": "carbon-components-svelte/src/Link/Link.svelte"
+    },
+    "OutboundLink": {
+      "path": "carbon-components-svelte/src/Link/OutboundLink.svelte"
+    },
+    "ImageLoader": {
+      "path": "carbon-components-svelte/src/ImageLoader/ImageLoader.svelte"
+    },
+    "LocalStorage": {
+      "path": "carbon-components-svelte/src/LocalStorage/LocalStorage.svelte"
+    },
+    "ListBoxField": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxField.svelte"
+    },
+    "ListBoxMenu": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxMenu.svelte"
+    },
+    "ListBoxMenuIcon": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxMenuIcon.svelte"
+    },
+    "ListBoxSelection": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxSelection.svelte"
+    },
+    "ListBoxMenuItem": {
+      "path": "carbon-components-svelte/src/ListBox/ListBoxMenuItem.svelte"
+    },
+    "ListItem": {
+      "path": "carbon-components-svelte/src/ListItem/ListItem.svelte"
+    },
+    "Loading": {
+      "path": "carbon-components-svelte/src/Loading/Loading.svelte"
+    },
+    "Modal": {
+      "path": "carbon-components-svelte/src/Modal/Modal.svelte"
+    },
+    "ListBox": {
+      "path": "carbon-components-svelte/src/ListBox/ListBox.svelte"
+    },
+    "NumberInput": {
+      "path": "carbon-components-svelte/src/NumberInput/NumberInput.svelte"
+    },
+    "NumberInputSkeleton": {
+      "path": "carbon-components-svelte/src/NumberInput/NumberInputSkeleton.svelte"
+    },
+    "MultiSelect": {
+      "path": "carbon-components-svelte/src/MultiSelect/MultiSelect.svelte"
+    },
+    "InlineNotification": {
+      "path": "carbon-components-svelte/src/Notification/InlineNotification.svelte"
+    },
+    "NotificationActionButton": {
+      "path": "carbon-components-svelte/src/Notification/NotificationActionButton.svelte"
+    },
+    "NotificationButton": {
+      "path": "carbon-components-svelte/src/Notification/NotificationButton.svelte"
+    },
+    "NotificationIcon": {
+      "path": "carbon-components-svelte/src/Notification/NotificationIcon.svelte"
+    },
+    "NotificationTextDetails": {
+      "path": "carbon-components-svelte/src/Notification/NotificationTextDetails.svelte"
+    },
+    "ToastNotification": {
+      "path": "carbon-components-svelte/src/Notification/ToastNotification.svelte"
+    },
+    "OrderedList": {
+      "path": "carbon-components-svelte/src/OrderedList/OrderedList.svelte"
+    },
+    "PaginationSkeleton": {
+      "path": "carbon-components-svelte/src/Pagination/PaginationSkeleton.svelte"
+    },
+    "Pagination": {
+      "path": "carbon-components-svelte/src/Pagination/Pagination.svelte"
+    },
+    "OverflowMenuItem": {
+      "path": "carbon-components-svelte/src/OverflowMenu/OverflowMenuItem.svelte"
+    },
+    "OverflowMenu": {
+      "path": "carbon-components-svelte/src/OverflowMenu/OverflowMenu.svelte"
+    },
+    "PaginationItem": {
+      "path": "carbon-components-svelte/src/PaginationNav/PaginationItem.svelte"
+    },
+    "PaginationNav": {
+      "path": "carbon-components-svelte/src/PaginationNav/PaginationNav.svelte"
+    },
+    "PaginationOverflow": {
+      "path": "carbon-components-svelte/src/PaginationNav/PaginationOverflow.svelte"
+    },
+    "ProgressBar": {
+      "path": "carbon-components-svelte/src/ProgressBar/ProgressBar.svelte"
+    },
+    "Popover": {
+      "path": "carbon-components-svelte/src/Popover/Popover.svelte"
+    },
+    "RadioButton": {
+      "path": "carbon-components-svelte/src/RadioButton/RadioButton.svelte"
+    },
+    "RadioButtonSkeleton": {
+      "path": "carbon-components-svelte/src/RadioButton/RadioButtonSkeleton.svelte"
+    },
+    "Search": {
+      "path": "carbon-components-svelte/src/Search/Search.svelte"
+    },
+    "SearchSkeleton": {
+      "path": "carbon-components-svelte/src/Search/SearchSkeleton.svelte"
+    },
+    "ProgressIndicatorSkeleton": {
+      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressIndicatorSkeleton.svelte"
+    },
+    "ProgressIndicator": {
+      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressIndicator.svelte"
+    },
+    "RadioButtonGroup": {
+      "path": "carbon-components-svelte/src/RadioButtonGroup/RadioButtonGroup.svelte"
+    },
+    "ProgressStep": {
+      "path": "carbon-components-svelte/src/ProgressIndicator/ProgressStep.svelte"
+    },
+    "RecursiveList": {
+      "path": "carbon-components-svelte/src/RecursiveList/RecursiveList.svelte"
+    },
+    "RecursiveListItem": {
+      "path": "carbon-components-svelte/src/RecursiveList/RecursiveListItem.svelte"
+    },
+    "Select": {
+      "path": "carbon-components-svelte/src/Select/Select.svelte"
+    },
+    "SelectItem": {
+      "path": "carbon-components-svelte/src/Select/SelectItem.svelte"
+    },
+    "SelectItemGroup": {
+      "path": "carbon-components-svelte/src/Select/SelectItemGroup.svelte"
+    },
+    "SelectSkeleton": {
+      "path": "carbon-components-svelte/src/Select/SelectSkeleton.svelte"
+    },
+    "SkeletonPlaceholder": {
+      "path": "carbon-components-svelte/src/SkeletonPlaceholder/SkeletonPlaceholder.svelte"
+    },
+    "SkeletonText": {
+      "path": "carbon-components-svelte/src/SkeletonText/SkeletonText.svelte"
+    },
+    "Slider": {
+      "path": "carbon-components-svelte/src/Slider/Slider.svelte"
+    },
+    "SliderSkeleton": {
+      "path": "carbon-components-svelte/src/Slider/SliderSkeleton.svelte"
+    },
+    "Tag": {
+      "path": "carbon-components-svelte/src/Tag/Tag.svelte"
+    },
+    "TagSkeleton": {
+      "path": "carbon-components-svelte/src/Tag/TagSkeleton.svelte"
+    },
+    "Tab": {
+      "path": "carbon-components-svelte/src/Tabs/Tab.svelte"
+    },
+    "TabContent": {
+      "path": "carbon-components-svelte/src/Tabs/TabContent.svelte"
+    },
+    "TabsSkeleton": {
+      "path": "carbon-components-svelte/src/Tabs/TabsSkeleton.svelte"
+    },
+    "Tabs": {
+      "path": "carbon-components-svelte/src/Tabs/Tabs.svelte"
+    },
+    "TextArea": {
+      "path": "carbon-components-svelte/src/TextArea/TextArea.svelte"
+    },
+    "TextAreaSkeleton": {
+      "path": "carbon-components-svelte/src/TextArea/TextAreaSkeleton.svelte"
+    },
+    "StructuredList": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredList.svelte"
+    },
+    "StructuredListBody": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListBody.svelte"
+    },
+    "StructuredListCell": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListCell.svelte"
+    },
+    "StructuredListInput": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListInput.svelte"
+    },
+    "StructuredListRow": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListRow.svelte"
+    },
+    "StructuredListHead": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListHead.svelte"
+    },
+    "StructuredListSkeleton": {
+      "path": "carbon-components-svelte/src/StructuredList/StructuredListSkeleton.svelte"
+    },
+    "TextInput": {
+      "path": "carbon-components-svelte/src/TextInput/TextInput.svelte"
+    },
+    "TimePicker": {
+      "path": "carbon-components-svelte/src/TimePicker/TimePicker.svelte"
+    },
+    "TextInputSkeleton": {
+      "path": "carbon-components-svelte/src/TextInput/TextInputSkeleton.svelte"
+    },
+    "PasswordInput": {
+      "path": "carbon-components-svelte/src/TextInput/PasswordInput.svelte"
+    },
+    "TimePickerSelect": {
+      "path": "carbon-components-svelte/src/TimePicker/TimePickerSelect.svelte"
+    },
+    "Toggle": {
+      "path": "carbon-components-svelte/src/Toggle/Toggle.svelte"
+    },
+    "ToggleSkeleton": {
+      "path": "carbon-components-svelte/src/Toggle/ToggleSkeleton.svelte"
+    },
+    "ClickableTile": {
+      "path": "carbon-components-svelte/src/Tile/ClickableTile.svelte"
+    },
+    "ExpandableTile": {
+      "path": "carbon-components-svelte/src/Tile/ExpandableTile.svelte"
+    },
+    "RadioTile": {
+      "path": "carbon-components-svelte/src/Tile/RadioTile.svelte"
+    },
+    "SelectableTile": {
+      "path": "carbon-components-svelte/src/Tile/SelectableTile.svelte"
+    },
+    "Tile": {
+      "path": "carbon-components-svelte/src/Tile/Tile.svelte"
+    },
+    "TileGroup": {
+      "path": "carbon-components-svelte/src/Tile/TileGroup.svelte"
+    },
+    "Theme": {
+      "path": "carbon-components-svelte/src/Theme/Theme.svelte"
+    },
+    "TooltipDefinition": {
+      "path": "carbon-components-svelte/src/TooltipDefinition/TooltipDefinition.svelte"
+    },
+    "ToggleSmall": {
+      "path": "carbon-components-svelte/src/ToggleSmall/ToggleSmall.svelte"
+    },
+    "ToggleSmallSkeleton": {
+      "path": "carbon-components-svelte/src/ToggleSmall/ToggleSmallSkeleton.svelte"
+    },
+    "Tooltip": {
+      "path": "carbon-components-svelte/src/Tooltip/Tooltip.svelte"
+    },
+    "TooltipFooter": {
+      "path": "carbon-components-svelte/src/Tooltip/TooltipFooter.svelte"
+    },
+    "TooltipIcon": {
+      "path": "carbon-components-svelte/src/TooltipIcon/TooltipIcon.svelte"
+    },
+    "Truncate": {
+      "path": "carbon-components-svelte/src/Truncate/Truncate.svelte"
+    },
+    "TreeView": {
+      "path": "carbon-components-svelte/src/TreeView/TreeView.svelte"
+    },
+    "TreeViewNodeList": {
+      "path": "carbon-components-svelte/src/TreeView/TreeViewNodeList.svelte"
+    },
+    "TreeViewNode": {
+      "path": "carbon-components-svelte/src/TreeView/TreeViewNode.svelte"
+    },
+    "UnorderedList": {
+      "path": "carbon-components-svelte/src/UnorderedList/UnorderedList.svelte"
+    },
+    "Content": {
+      "path": "carbon-components-svelte/src/UIShell/Content.svelte"
+    },
+    "HeaderGlobalAction": {
+      "path": "carbon-components-svelte/src/UIShell/HeaderGlobalAction.svelte"
+    },
+    "HeaderSearch": {
+      "path": "carbon-components-svelte/src/UIShell/HeaderSearch.svelte"
+    },
+    "SkipToContent": {
+      "path": "carbon-components-svelte/src/UIShell/SkipToContent.svelte"
+    },
+    "SideNavDivider": {
+      "path": "carbon-components-svelte/src/UIShell/SideNavDivider.svelte"
+    },
+    "navStore": {
+      "path": "carbon-components-svelte/src/UIShell/navStore.js"
+    },
+    "searchStore": {
+      "path": "carbon-components-svelte/src/UIShell/searchStore.js"
+    },
+    "Add16": {
+      "path": "carbon-components-svelte/src/icons/Add16.svelte"
+    },
+    "AppSwitcher20": {
+      "path": "carbon-components-svelte/src/icons/AppSwitcher20.svelte"
+    },
+    "Calendar16": {
+      "path": "carbon-components-svelte/src/icons/Calendar16.svelte"
+    },
+    "ArrowUp20": {
+      "path": "carbon-components-svelte/src/icons/ArrowUp20.svelte"
+    },
+    "CaretDown16": {
+      "path": "carbon-components-svelte/src/icons/CaretDown16.svelte"
+    },
+    "ArrowsVertical20": {
+      "path": "carbon-components-svelte/src/icons/ArrowsVertical20.svelte"
+    },
+    "CaretRight16": {
+      "path": "carbon-components-svelte/src/icons/CaretRight16.svelte"
+    },
+    "CaretLeft16": {
+      "path": "carbon-components-svelte/src/icons/CaretLeft16.svelte"
+    },
+    "Checkmark16": {
+      "path": "carbon-components-svelte/src/icons/Checkmark16.svelte"
+    },
+    "CheckmarkFilled16": {
+      "path": "carbon-components-svelte/src/icons/CheckmarkFilled16.svelte"
+    },
+    "CheckmarkFilled20": {
+      "path": "carbon-components-svelte/src/icons/CheckmarkFilled20.svelte"
+    },
+    "CheckmarkOutline16": {
+      "path": "carbon-components-svelte/src/icons/CheckmarkOutline16.svelte"
+    },
+    "ChevronDown16": {
+      "path": "carbon-components-svelte/src/icons/ChevronDown16.svelte"
+    },
+    "ChevronDownGlyph": {
+      "path": "carbon-components-svelte/src/icons/ChevronDownGlyph.svelte"
+    },
+    "ChevronRight16": {
+      "path": "carbon-components-svelte/src/icons/ChevronRight16.svelte"
+    },
+    "CircleDash16": {
+      "path": "carbon-components-svelte/src/icons/CircleDash16.svelte"
+    },
+    "Close20": {
+      "path": "carbon-components-svelte/src/icons/Close20.svelte"
+    },
+    "Copy16": {
+      "path": "carbon-components-svelte/src/icons/Copy16.svelte"
+    },
+    "Close16": {
+      "path": "carbon-components-svelte/src/icons/Close16.svelte"
+    },
+    "ErrorFilled20": {
+      "path": "carbon-components-svelte/src/icons/ErrorFilled20.svelte"
+    },
+    "ErrorFilled16": {
+      "path": "carbon-components-svelte/src/icons/ErrorFilled16.svelte"
+    },
+    "Incomplete16": {
+      "path": "carbon-components-svelte/src/icons/Incomplete16.svelte"
+    },
+    "EditOff16": {
+      "path": "carbon-components-svelte/src/icons/EditOff16.svelte"
+    },
+    "Information16": {
+      "path": "carbon-components-svelte/src/icons/Information16.svelte"
+    },
+    "InformationFilled20": {
+      "path": "carbon-components-svelte/src/icons/InformationFilled20.svelte"
+    },
+    "InformationSquareFilled20": {
+      "path": "carbon-components-svelte/src/icons/InformationSquareFilled20.svelte"
+    },
+    "Launch16": {
+      "path": "carbon-components-svelte/src/icons/Launch16.svelte"
+    },
+    "Menu20": {
+      "path": "carbon-components-svelte/src/icons/Menu20.svelte"
+    },
+    "OverflowMenuHorizontal16": {
+      "path": "carbon-components-svelte/src/icons/OverflowMenuHorizontal16.svelte"
+    },
+    "Search20": {
+      "path": "carbon-components-svelte/src/icons/Search20.svelte"
+    },
+    "Settings16": {
+      "path": "carbon-components-svelte/src/icons/Settings16.svelte"
+    },
+    "OverflowMenuVertical16": {
+      "path": "carbon-components-svelte/src/icons/OverflowMenuVertical16.svelte"
+    },
+    "Search16": {
+      "path": "carbon-components-svelte/src/icons/Search16.svelte"
+    },
+    "Subtract16": {
+      "path": "carbon-components-svelte/src/icons/Subtract16.svelte"
+    },
+    "View16": {
+      "path": "carbon-components-svelte/src/icons/View16.svelte"
+    },
+    "ViewOff16": {
+      "path": "carbon-components-svelte/src/icons/ViewOff16.svelte"
+    },
+    "Warning16": {
+      "path": "carbon-components-svelte/src/icons/Warning16.svelte"
+    },
+    "WarningAltFilled16": {
+      "path": "carbon-components-svelte/src/icons/WarningAltFilled16.svelte"
+    },
+    "WarningAltFilled20": {
+      "path": "carbon-components-svelte/src/icons/WarningAltFilled20.svelte"
+    },
+    "WarningFilled16": {
+      "path": "carbon-components-svelte/src/icons/WarningFilled16.svelte"
+    },
+    "WarningFilled20": {
+      "path": "carbon-components-svelte/src/icons/WarningFilled20.svelte"
+    },
+    "HamburgerMenu": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/HamburgerMenu.svelte"
+    },
+    "SideNav": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNav.svelte"
+    },
+    "SideNavMenu": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavMenu.svelte"
+    },
+    "SideNavItems": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavItems.svelte"
+    },
+    "SideNavMenuItem": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavMenuItem.svelte"
+    },
+    "SideNavLink": {
+      "path": "carbon-components-svelte/src/UIShell/SideNav/SideNavLink.svelte"
+    },
+    "Header": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/Header.svelte"
+    },
+    "HeaderAction": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderAction.svelte"
+    },
+    "HeaderActionLink": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderActionLink.svelte"
+    },
+    "HeaderActionSearch": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderActionSearch.svelte"
+    },
+    "HeaderNavItem": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNavItem.svelte"
+    },
+    "HeaderNavMenu": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNavMenu.svelte"
+    },
+    "HeaderNav": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderNav.svelte"
+    },
+    "HeaderPanelDivider": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelDivider.svelte"
+    },
+    "HeaderPanelLinks": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelLinks.svelte"
+    },
+    "HeaderPanelLink": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderPanelLink.svelte"
+    },
+    "HeaderUtilities": {
+      "path": "carbon-components-svelte/src/UIShell/GlobalHeader/HeaderUtilities.svelte"
+    }
+  }
+}

--- a/src/walk-and-replace.ts
+++ b/src/walk-and-replace.ts
@@ -77,6 +77,11 @@ interface NodeImportDeclaration extends NodeMeta {
   }>;
 }
 
+interface NodeExportSpecifier extends NodeMeta {
+  type: "ExportSpecifier";
+  local: { name: string };
+}
+
 interface NodeDeclaration extends NodeMeta {
   type: "Declaration";
   property: string;
@@ -151,14 +156,14 @@ export interface NodeChildString extends NodeMeta {
   value: string;
 }
 
-type Node =
+export type Node =
   | NodeElement
   | NodeImportDeclaration
+  | NodeExportSpecifier
   | NodeDeclaration
   | NodeRule
   | NodeAtRule
   | NodeFunction;
-
 export function walkAndReplace(
   options: WalkAndReplaceOptions,
   replaceWith: (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "declaration": true,
     "emitDeclarationOnly": true,
     "esModuleInterop": true,
+    "downlevelIteration": true,
     "lib": ["ESNext", "DOM.Iterable"],
     "moduleResolution": "Node",
     "outDir": "dist",


### PR DESCRIPTION
Previously, `optimizeImports` would pre-build an object that mapped all Svelte components from `carbon-components-svelte/src`.

The correct behavior should be to only map files exported from `src/index.js` (the "API" of the library).

This change also sets up work to resolve https://github.com/carbon-design-system/carbon-components-svelte/issues/1102 because it is not exclusive to `.svelte` files.