### PR TITLE
fix(optimize-css): only remove `bx--` prefixed classes

### DIFF
--- a/scripts/extract-selectors.ts
+++ b/scripts/extract-selectors.ts
@@ -1,6 +1,5 @@
 import { parse, walk } from "svelte/compiler";
-
-const CARBON_PREFIX = /bx--/;
+import { CARBON_PREFIX } from "../src/constants";
 
 type ExtractSelectorsProps = {
   code: string;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,8 @@ export const enum CarbonSvelte {
   Pictograms = "carbon-pictograms-svelte",
 }
 
+export const CARBON_PREFIX = /bx--/;
+
 export const RE_EXT_SVELTE = /\.svelte$/;
 
 export const RE_EXT_CSS = /\.css$/;

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import postcss from "postcss";
 import discardEmpty from "postcss-discard-empty";
 import { components } from "../component-index";
+import { CARBON_PREFIX } from "../constants";
 
 export type OptimizeCssOptions = {
   /**
@@ -54,8 +55,8 @@ export function createOptimizedCss(
       Rule(node) {
         const selector = node.selector;
 
-        // Ensure that the selector contains a class.
-        if (selector.includes(".")) {
+        // Ensure that the selector contains a Carbon prefix.
+        if (CARBON_PREFIX.test(selector)) {
           // Selectors may contain multiple classes, separated by a comma.
           const classes = selector.split(",").filter((selectee) => {
             const value = selectee.trim() ?? "";


### PR DESCRIPTION
Fixes #55

Currently, the `optimizeCss` plugin is too aggressive. It will remove non-Carbon prefixed selectors.

The fix is to first check that selectors actually include the Carbon `bx--` prefix. This is an even more conservative approach, However, the critical mandate is to avoid false positives.

With this change, I've tested that the following selectors are not removed:

- Scoped Svelte style
- Global Svelte style (e.g., `:global()`)
- Global selector from CSS StyleSheet
- Global selector overriding a Carbon class