### PR TITLE
ci: improvements to workflows

### DIFF
--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install dependencies
         run: npm install --force
 
+      - name: Build library
+        run: npm run prepack
+
       - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish-to-npm.yml
+++ b/.github/workflows/publish-to-npm.yml
@@ -16,12 +16,10 @@ jobs:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Publish package
+      - name: Install dependencies
+        run: npm install --force
+
+      - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-        # Currently, only npm supports publishing packages with provenance
-        # https://docs.npmjs.com/generating-provenance-statements
-        run: |
-          npm install --force
-          npm publish --provenance --access public
+        run: npm publish --provenance --access public

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.1.2
+
+      - name: Install dependencies
+        run: bun install
 
       - name: Run unit tests
-        run: |
-          bun install
-          bun test
+        run: bun test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "index:components": "bun scripts/index-components.ts",
-    "prepack": "bunx --bun tsc -p tsconfig.build.json",
+    "prepack": "tsc -p tsconfig.build.json",
     "format": "bunx --bun prettier --write ."
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "index:components": "bun scripts/index-components.ts",
-    "prepack": "tsc -p tsconfig.build.json",
-    "format": "prettier --write ."
+    "prepack": "bunx --bun tsc -p tsconfig.build.json",
+    "format": "bunx --bun prettier --write ."
   },
   "dependencies": {
     "magic-string": "^0.30.8",


### PR DESCRIPTION
Break workflows into steps.

For `test.yml`, pin the Bun version so that GitHub Actions will cache it. This may marginally speed up subsequent runs.