### PR TITLE
fix(optimize-css): do not print diff if zero

### DIFF
--- a/src/plugins/print-diff.ts
+++ b/src/plugins/print-diff.ts
@@ -32,6 +32,11 @@ export function printDiff(props: {
 
   const original_size = stringSizeInKB(original_css.toString());
   const optimized_size = stringSizeInKB(optimized_css);
+
+  if (original_size === optimized_size) {
+    return;
+  }
+
   const original = toHumanReadableSize(original_size);
   const optimized = toHumanReadableSize(optimized_size);
   const original_display = padIfNeeded(original, optimized);

--- a/tests/print-diff.test.ts
+++ b/tests/print-diff.test.ts
@@ -22,4 +22,18 @@ describe("print-diff", () => {
       ["After: ", "0.02 kB", "(-37.5%)\n"],
     ]);
   });
+
+  test("no diff", () => {
+    const log = jest.spyOn(console, "log");
+
+    expect(
+      printDiff({
+        original_css: "body { color: red; }",
+        optimized_css: "body { color: red; }",
+        id: "id",
+      }),
+    );
+
+    expect(log.mock.calls).toEqual([]);
+  });
 });


### PR DESCRIPTION
If the diff is zero, do not print the comparison output.