### PR TITLE
fix(optimize-css): do not remove custom `@font` rules

### DIFF
--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -104,6 +104,11 @@ export function createOptimizedCss(options: CreateOptimizedCssOptions) {
             }
           });
 
+          // Do not proceed if font is not IBM Plex.
+          if (!attributes["font-family"].startsWith("IBM Plex")) {
+            return;
+          }
+
           const is_mono =
             attributes["font-style"] === "normal" &&
             attributes["font-family"] === "IBM Plex Mono" &&

--- a/tests/__snapshots__/create-optimized-css.test.ts.snap
+++ b/tests/__snapshots__/create-optimized-css.test.ts.snap
@@ -9,8 +9,13 @@ exports[`create-optimized-css removes unused selectors 1`] = `
       "
 `;
 
-exports[`create-optimized-css removes unused @font rules 1`] = `
+exports[`create-optimized-css removes unused IBM @font rules 1`] = `
 "
+    @font-face {
+      font-family: 'CustomFont';
+      src: url('path/to/custom-font.ttf');
+    }
+
     @font-face {
       font-display: auto;
       font-family: IBM Plex Mono;
@@ -36,6 +41,11 @@ exports[`create-optimized-css removes unused @font rules 1`] = `
 
 exports[`create-optimized-css preserves all IBM fonts 1`] = `
 "
+    @font-face {
+      font-family: 'CustomFont';
+      src: url('path/to/custom-font.ttf');
+    }
+
     @font-face {
       font-display: auto;
       font-family: IBM Plex Mono;

--- a/tests/create-optimized-css.test.ts
+++ b/tests/create-optimized-css.test.ts
@@ -18,6 +18,11 @@ describe("create-optimized-css", () => {
 
   const font_rules = `
     @font-face {
+      font-family: 'CustomFont';
+      src: url('path/to/custom-font.ttf');
+    }
+
+    @font-face {
       font-display: auto;
       font-family: IBM Plex Mono;
       font-style: normal;


### PR DESCRIPTION
Fixes #65

Currently, `preserveAllIBMFonts: false` (the default configuration), will remove non-product IBM `@font-face` rules. However, it also unintentionally removes custom `@font-face` rules.

The fix is to first check that the rule-to-remove is actually IBM Plex.