### PR TITLE
fix(optimize-imports): append line break to optimized path

### DIFF
--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -15,10 +15,12 @@ function rewriteImport(
 
   for (const specifier of node.specifiers) {
     const fragment = map(specifier);
-    if (fragment) content += fragment;
+    if (fragment) {
+      content += fragment + (!fragment.endsWith('\n') ? '\n' : '');
+    }
   }
 
-  if (content) s.overwrite(node.start, node.end, content);
+  if (content) s.overwrite(node.start, node.end, content.trimEnd());
 }
 
 export const optimizeImports: SveltePreprocessor<"script"> = () => {

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -38,7 +38,8 @@ import { Airplane as Airplane2 } from "carbon-pictograms-svelte";
 import Airplane3 from "carbon-pictograms-svelte/lib/Airplane.svelte";`,
       }),
     )
-      .toEqual(`import Accordion from "carbon-components-svelte/src/Accordion/Accordion.svelte";import AccordionItem from "carbon-components-svelte/src/Accordion/AccordionItem.svelte";
+      .toEqual(`import Accordion from "carbon-components-svelte/src/Accordion/Accordion.svelte";
+import AccordionItem from "carbon-components-svelte/src/Accordion/AccordionItem.svelte";
 import Accordion2 from "carbon-components-svelte/src/Accordion/Accordion.svelte";
 import breakpoints from "carbon-components-svelte/src/Breakpoint/breakpoints.js";
 
@@ -62,17 +63,17 @@ import Airplane3 from "carbon-pictograms-svelte/lib/Airplane.svelte";`);
   test("mixed imports should be handled correctly", () => {
     expect(
       preprocess({
-        content: `
-          import { Accordion, AccordionItem, breakpoints as bp } from "carbon-components-svelte";
-          import { Add, Download } from "carbon-icons-svelte";
-          import { Airplane, Analytics } from "carbon-pictograms-svelte";
-        `,
+        content: `import { Accordion, AccordionItem, breakpoints as bp } from "carbon-components-svelte";
+import { Add, Download } from "carbon-icons-svelte";
+import { Airplane, Analytics } from "carbon-pictograms-svelte";`,
       }),
-    ).toEqual(`
-          import Accordion from "carbon-components-svelte/src/Accordion/Accordion.svelte";import AccordionItem from "carbon-components-svelte/src/Accordion/AccordionItem.svelte";import bp from "carbon-components-svelte/src/Breakpoint/breakpoints.js";
-          import Add from "carbon-icons-svelte/lib/Add.svelte";import Download from "carbon-icons-svelte/lib/Download.svelte";
-          import Airplane from "carbon-pictograms-svelte/lib/Airplane.svelte";import Analytics from "carbon-pictograms-svelte/lib/Analytics.svelte";
-        `);
+    ).toEqual(`import Accordion from "carbon-components-svelte/src/Accordion/Accordion.svelte";
+import AccordionItem from "carbon-components-svelte/src/Accordion/AccordionItem.svelte";
+import bp from "carbon-components-svelte/src/Breakpoint/breakpoints.js";
+import Add from "carbon-icons-svelte/lib/Add.svelte";
+import Download from "carbon-icons-svelte/lib/Download.svelte";
+import Airplane from "carbon-pictograms-svelte/lib/Airplane.svelte";
+import Analytics from "carbon-pictograms-svelte/lib/Analytics.svelte";`)
   });
 
   test("default imports should be preserved", () => {


### PR DESCRIPTION
A small nicety – when creating an optimized import statement, append a line break if it doesn't already exist.

This is because multiple barrel imports in a single statement are converted into individual direct imports.