### PR TITLE
chore(biome): enable `useImportExtensions`

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -23,10 +23,23 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "recommended": true,
+      "correctness": {
+        "useImportExtensions": "error"
+      }
     }
   },
   "overrides": [
+    {
+      "includes": ["examples/**"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "useImportExtensions": "off"
+          }
+        }
+      }
+    },
     {
       "includes": ["**/*.svelte"],
       "linter": {

--- a/scripts/extract-selectors.ts
+++ b/scripts/extract-selectors.ts
@@ -1,6 +1,6 @@
 import { type ANode, walk } from "estree-walker";
 import { parse } from "svelte/compiler";
-import { CARBON_PREFIX } from "../src/constants";
+import { CARBON_PREFIX } from "../src/constants.ts";
 
 type ExtractSelectorsProps = {
   code: string;

--- a/scripts/index-components.ts
+++ b/scripts/index-components.ts
@@ -2,9 +2,9 @@ import path from "node:path";
 import { Glob } from "bun";
 import { walk } from "estree-walker";
 import { parse } from "svelte/compiler";
-import { CarbonSvelte } from "../src/constants";
-import { isSvelteFile } from "../src/utils";
-import { extractSelectors } from "./extract-selectors";
+import { CarbonSvelte } from "../src/constants.ts";
+import { isSvelteFile } from "../src/utils.ts";
+import { extractSelectors } from "./extract-selectors.ts";
 
 const carbon_path = path.join("node_modules", CarbonSvelte.Components);
 const index_js = path.join(carbon_path, "src/index.js");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { default as OptimizeCssPlugin } from "./plugins/OptimizeCssPlugin";
-export { optimizeCss } from "./plugins/optimize-css";
-export { optimizeImports } from "./preprocessors/optimize-imports";
+export { default as OptimizeCssPlugin } from "./plugins/OptimizeCssPlugin.ts";
+export { optimizeCss } from "./plugins/optimize-css.ts";
+export { optimizeImports } from "./preprocessors/optimize-imports.ts";

--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -1,8 +1,8 @@
 import type { Compiler } from "webpack";
-import { isCarbonSvelteImport, isCssFile } from "../utils";
-import type { OptimizeCssOptions } from "./create-optimized-css";
-import { createOptimizedCss } from "./create-optimized-css";
-import { printDiff } from "./print-diff";
+import { isCarbonSvelteImport, isCssFile } from "../utils.ts";
+import type { OptimizeCssOptions } from "./create-optimized-css.ts";
+import { createOptimizedCss } from "./create-optimized-css.ts";
+import { printDiff } from "./print-diff.ts";
 
 // Webpack plugin to optimize CSS for Carbon Svelte components.
 class OptimizeCssPlugin {

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -1,8 +1,8 @@
 import path from "node:path";
 import postcss from "postcss";
 import discardEmpty from "postcss-discard-empty";
-import { components } from "../component-index";
-import { CARBON_PREFIX } from "../constants";
+import { components } from "../component-index.ts";
+import { CARBON_PREFIX } from "../constants.ts";
 
 export type OptimizeCssOptions = {
   /**

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -1,8 +1,8 @@
 import type { Plugin } from "vite";
-import { isCarbonSvelteImport, isCssFile } from "../utils";
-import type { OptimizeCssOptions } from "./create-optimized-css";
-import { createOptimizedCss } from "./create-optimized-css";
-import { printDiff } from "./print-diff";
+import { isCarbonSvelteImport, isCssFile } from "../utils.ts";
+import type { OptimizeCssOptions } from "./create-optimized-css.ts";
+import { createOptimizedCss } from "./create-optimized-css.ts";
+import { printDiff } from "./print-diff.ts";
 
 // Vite plugin (Rollup-compatible) to optimize CSS for Carbon Svelte components.
 export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {

--- a/src/plugins/print-diff.ts
+++ b/src/plugins/print-diff.ts
@@ -1,4 +1,4 @@
-import { BITS_DENOM } from "../constants";
+import { BITS_DENOM } from "../constants.ts";
 
 const formatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 });
 

--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -3,8 +3,8 @@ import { walk } from "estree-walker";
 import MagicString from "magic-string";
 import { parse } from "svelte/compiler";
 import type { SveltePreprocessor } from "svelte/types/compiler/preprocess";
-import { components } from "../component-index";
-import { CarbonSvelte } from "../constants";
+import { components } from "../component-index.ts";
+import { CarbonSvelte } from "../constants.ts";
 
 function rewriteImport(
   s: MagicString,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { CarbonSvelte, RE_EXT_CSS, RE_EXT_SVELTE } from "./constants";
+import { CarbonSvelte, RE_EXT_CSS, RE_EXT_SVELTE } from "./constants.ts";
 
 export function isSvelteFile(id: string): id is `${string}.svelte` {
   return RE_EXT_SVELTE.test(id);

--- a/tests/OptimizeCssPlugin.test.ts
+++ b/tests/OptimizeCssPlugin.test.ts
@@ -1,6 +1,6 @@
 import type { Compiler } from "webpack";
-import { CarbonSvelte } from "../src/constants";
-import OptimizeCssPlugin from "../src/plugins/OptimizeCssPlugin";
+import { CarbonSvelte } from "../src/constants.ts";
+import OptimizeCssPlugin from "../src/plugins/OptimizeCssPlugin.ts";
 
 // Mock webpack compiler and related types
 const createMockCompiler = (

--- a/tests/create-optimized-css.test.ts
+++ b/tests/create-optimized-css.test.ts
@@ -1,4 +1,4 @@
-import { createOptimizedCss } from "carbon-preprocess-svelte/plugins/create-optimized-css";
+import { createOptimizedCss } from "carbon-preprocess-svelte/plugins/create-optimized-css.ts";
 
 describe("create-optimized-css", () => {
   test("removes unused selectors", () => {

--- a/tests/extract-selectors.test.ts
+++ b/tests/extract-selectors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { extractSelectors } from "../scripts/extract-selectors";
+import { extractSelectors } from "../scripts/extract-selectors.ts";
 
 describe("extractSelectors", () => {
   test("extracts single class from class attribute", () => {

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -1,4 +1,4 @@
-import { optimizeImports } from "carbon-preprocess-svelte";
+import { optimizeImports } from "carbon-preprocess-svelte/index.ts";
 import type { Preprocessor, Processed } from "svelte/compiler";
 
 const preprocess = (options?: Partial<Parameters<Preprocessor>[0]>) => {

--- a/tests/print-diff.test.ts
+++ b/tests/print-diff.test.ts
@@ -1,4 +1,4 @@
-import { printDiff } from "carbon-preprocess-svelte/plugins/print-diff";
+import { printDiff } from "carbon-preprocess-svelte/plugins/print-diff.ts";
 
 describe("print-diff", () => {
   beforeEach(() => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,5 +1,5 @@
-import { CarbonSvelte } from "../src/constants";
-import { isCarbonSvelteImport, isCssFile, isSvelteFile } from "../src/utils";
+import { CarbonSvelte } from "../src/constants.ts";
+import { isCarbonSvelteImport, isCssFile, isSvelteFile } from "../src/utils.ts";
 
 describe("isSvelteFile", () => {
   test("returns true for .svelte files", () => {


### PR DESCRIPTION
Enforces explicit file extensions, excepting `examples/*`.