### PR TITLE
chore(components): re-index using v0.93.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.3.7",
         "@types/bun": "^1.3.2",
         "@typescript/native-preview": "^7.0.0-dev.20251118.1",
-        "carbon-components-svelte": "0.91.0",
+        "carbon-components-svelte": "0.93.0",
         "culls": "^0.1.1",
         "svelte": "^5.43.11",
         "vite": "^7.2.2",
@@ -237,7 +237,7 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001748", "", {}, "sha512-5P5UgAr0+aBmNiplks08JLw+AW/XG/SurlgZLgB1dDLfAw7EfRGxIwzPHxdSCGY/BTKDqIVyJL87cCN6s0ZR0w=="],
 
-    "carbon-components-svelte": ["carbon-components-svelte@0.91.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-qJQ0ihd4EFbLF31bE0sycYEjS0GVea4GV3npiYCDMOY7G7moL4vkAe03sI5YzLL1Qvow+cw/VG4Pyb7Gbvw5HQ=="],
+    "carbon-components-svelte": ["carbon-components-svelte@0.93.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-pSMX3izotAAIx8ieJzXbgkJMnKhsnFW/DoaF6T/aP97RlVIRoqAt16u+9Q08ZeYcZdcL1/TqSZRgIlZ6QBxXPg=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@biomejs/biome": "2.3.7",
     "@types/bun": "^1.3.2",
     "@typescript/native-preview": "^7.0.0-dev.20251118.1",
-    "carbon-components-svelte": "0.91.0",
+    "carbon-components-svelte": "0.93.0",
     "culls": "^0.1.1",
     "svelte": "^5.43.11",
     "vite": "^7.2.2",

--- a/src/component-index.ts
+++ b/src/component-index.ts
@@ -1727,6 +1727,27 @@ export const components: Record<string, { path: string; classes: string[] }> =
         ".bx--slider__thumb",
       ],
     },
+    Stack: {
+      path: "carbon-components-svelte/src/Stack/Stack.svelte",
+      classes: [
+        ".bx--stack",
+        ".bx--stack-vertical",
+        ".bx--stack-horizontal",
+        ".bx--stack-scale-1",
+        ".bx--stack-scale-2",
+        ".bx--stack-scale-3",
+        ".bx--stack-scale-4",
+        ".bx--stack-scale-5",
+        ".bx--stack-scale-6",
+        ".bx--stack-scale-7",
+        ".bx--stack-scale-8",
+        ".bx--stack-scale-9",
+        ".bx--stack-scale-10",
+        ".bx--stack-scale-11",
+        ".bx--stack-scale-12",
+        ".bx--stack-scale-13",
+      ],
+    },
     StructuredList: {
       path: "carbon-components-svelte/src/StructuredList/StructuredList.svelte",
       classes: [


### PR DESCRIPTION
v0.93.0 ships a new `Stack` component: https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.93.0