### PR TITLE
chore(components): re-index using v0.94.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.3.8",
         "@types/bun": "^1.3.3",
         "@typescript/native-preview": "^7.0.0-dev.20251127.1",
-        "carbon-components-svelte": "0.93.0",
+        "carbon-components-svelte": "0.94.0",
         "culls": "^0.1.2",
         "svelte": "^5.45.2",
         "vite": "^7.2.4",
@@ -235,7 +235,7 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001748", "", {}, "sha512-5P5UgAr0+aBmNiplks08JLw+AW/XG/SurlgZLgB1dDLfAw7EfRGxIwzPHxdSCGY/BTKDqIVyJL87cCN6s0ZR0w=="],
 
-    "carbon-components-svelte": ["carbon-components-svelte@0.93.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-pSMX3izotAAIx8ieJzXbgkJMnKhsnFW/DoaF6T/aP97RlVIRoqAt16u+9Q08ZeYcZdcL1/TqSZRgIlZ6QBxXPg=="],
+    "carbon-components-svelte": ["carbon-components-svelte@0.94.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-6nQuVHrMGBiHxSgorb74Dh822EAdcd94RjqSFeoOZ9pN4jApxB7bbWQZe2HwOtPcjND8+bX/FqbFjgfQxQM6vA=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@biomejs/biome": "2.3.8",
     "@types/bun": "^1.3.3",
     "@typescript/native-preview": "^7.0.0-dev.20251127.1",
-    "carbon-components-svelte": "0.93.0",
+    "carbon-components-svelte": "0.94.0",
     "culls": "^0.1.2",
     "svelte": "^5.45.2",
     "vite": "^7.2.4",

--- a/src/component-index.ts
+++ b/src/component-index.ts
@@ -1161,6 +1161,23 @@ export const components: Record<string, { path: string; classes: string[] }> =
         ".bx--inline-notification__icon",
       ],
     },
+    NotificationQueue: {
+      path: "carbon-components-svelte/src/Notification/NotificationQueue.svelte",
+      classes: [
+        ".bx--toast-notification",
+        ".bx--toast-notification--low-contrast",
+        ".bx--toast-notification--error",
+        ".bx--toast-notification--info",
+        ".bx--toast-notification--info-square",
+        ".bx--toast-notification--success",
+        ".bx--toast-notification--warning",
+        ".bx--toast-notification--warning-alt",
+        ".bx--toast-notification__details",
+        ".bx--toast-notification__title",
+        ".bx--toast-notification__subtitle",
+        ".bx--toast-notification__caption",
+      ],
+    },
     NumberInput: {
       path: "carbon-components-svelte/src/NumberInput/NumberInput.svelte",
       classes: [
@@ -1609,6 +1626,10 @@ export const components: Record<string, { path: string; classes: string[] }> =
         ".bx--tile__checkmark",
         ".bx--tile-content",
       ],
+    },
+    SelectableTileGroup: {
+      path: "carbon-components-svelte/src/Tile/SelectableTileGroup.svelte",
+      classes: [".bx--tile-group", ".bx--label"],
     },
     SelectItem: {
       path: "carbon-components-svelte/src/Select/SelectItem.svelte",


### PR DESCRIPTION
v0.94.0 ships new `NotificationQueue` and `SelectableTileGroup` components: https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.94.0
