### PR TITLE
chore(components): re-index using v0.95.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@biomejs/biome": "2.3.8",
         "@types/bun": "^1.3.3",
         "@typescript/native-preview": "^7.0.0-dev.20251127.1",
-        "carbon-components-svelte": "0.94.0",
+        "carbon-components-svelte": "0.95.0",
         "culls": "^0.1.2",
         "svelte": "^5.45.2",
         "vite": "^7.2.4",
@@ -235,7 +235,7 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001748", "", {}, "sha512-5P5UgAr0+aBmNiplks08JLw+AW/XG/SurlgZLgB1dDLfAw7EfRGxIwzPHxdSCGY/BTKDqIVyJL87cCN6s0ZR0w=="],
 
-    "carbon-components-svelte": ["carbon-components-svelte@0.94.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-6nQuVHrMGBiHxSgorb74Dh822EAdcd94RjqSFeoOZ9pN4jApxB7bbWQZe2HwOtPcjND8+bX/FqbFjgfQxQM6vA=="],
+    "carbon-components-svelte": ["carbon-components-svelte@0.95.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-2fkNfOnaWPj5d5wnBCSslgHsJXbuUGY7Ff4vAYON1+vxtc5mdiViJhPObMnRy39DkuLwslyABwYe+DXo1psWdA=="],
 
     "chrome-trace-event": ["chrome-trace-event@1.0.4", "", {}, "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ=="],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@biomejs/biome": "2.3.8",
     "@types/bun": "^1.3.3",
     "@typescript/native-preview": "^7.0.0-dev.20251127.1",
-    "carbon-components-svelte": "0.94.0",
+    "carbon-components-svelte": "0.95.0",
     "culls": "^0.1.2",
     "svelte": "^5.45.2",
     "vite": "^7.2.4",

--- a/src/component-index.ts
+++ b/src/component-index.ts
@@ -1436,6 +1436,10 @@ export const components: Record<string, { path: string; classes: string[] }> =
         ".bx--popover-contents",
       ],
     },
+    Portal: {
+      path: "carbon-components-svelte/src/Portal/Portal.svelte",
+      classes: [],
+    },
     ProgressBar: {
       path: "carbon-components-svelte/src/ProgressBar/ProgressBar.svelte",
       classes: [


### PR DESCRIPTION
v0.95.0 ships a new `Portal` component (albeit without classes in its initial state): https://github.com/carbon-design-system/carbon-components-svelte/releases/tag/v0.95.0