### PR TITLE
build: use Bun to compile library

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,10 @@ export default {
 This code is abridged; see [examples/webpack](examples/webpack) for a full set-up.
 
 ```js
-// webpack.config.js
-const { optimizeImports } = require("carbon-preprocess-svelte");
+// webpack.config.mjs
+import { optimizeImports } from "carbon-preprocess-svelte";
 
-module.exports = {
+export default {
   module: {
     rules: [
       {
@@ -261,12 +261,12 @@ For Webpack users, `OptimizeCssPlugin` is a drop-in replacement for `optimizeCss
 This code is abridged; see [examples/webpack](examples/webpack) for a full set-up.
 
 ```js
-// webpack.config.js
-const { OptimizeCssPlugin } = require("carbon-preprocess-svelte");
+// webpack.config.mjs
+import { OptimizeCssPlugin } from "carbon-preprocess-svelte";
 
 const PROD = process.env.NODE_ENV === "production";
 
-module.exports = {
+export default {
   plugins: [
     // Only apply the plugin when building for production.
     PROD && new OptimizeCssPlugin(),

--- a/bun.lock
+++ b/bun.lock
@@ -4,18 +4,16 @@
   "workspaces": {
     "": {
       "name": "carbon-preprocess-svelte",
-      "dependencies": {
+      "devDependencies": {
+        "@biomejs/biome": "2.3.11",
+        "@types/bun": "^1.3.6",
+        "@typescript/native-preview": "^7.0.0-dev.20260118.1",
+        "carbon-components-svelte": "0.98.0",
+        "culls": "^0.1.2",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.17",
         "postcss": "^8.5.4",
         "postcss-discard-empty": "^7.0.1",
-      },
-      "devDependencies": {
-        "@biomejs/biome": "2.3.11",
-        "@types/bun": "^1.3.6",
-        "@typescript/native-preview": "^7.0.0-dev.20251218.3",
-        "carbon-components-svelte": "0.98.0",
-        "culls": "^0.1.2",
         "svelte": "^5.46.4",
         "vite": "^7.3.1",
         "webpack": "^5.104.1",
@@ -163,21 +161,21 @@
 
     "@types/node": ["@types/node@22.10.7", "", { "dependencies": { "undici-types": "~6.20.0" } }, "sha512-V09KvXxFiutGp6B7XkpaDXlNadZxrzajcY50EuoLIpQ6WWYCSvf19lVIazzfIzQvhUN2HjX12spLojTnhuKlGg=="],
 
-    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20251218.3", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20251218.3", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20251218.3", "@typescript/native-preview-linux-arm": "7.0.0-dev.20251218.3", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20251218.3", "@typescript/native-preview-linux-x64": "7.0.0-dev.20251218.3", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20251218.3", "@typescript/native-preview-win32-x64": "7.0.0-dev.20251218.3" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-FxHW0n7KFG3QhcwRDsP/EWzkvjQYnIqfuDn1y0w4pl6KNh2aK9CRvHjA7bwpft64Tm5eCtYTHM+Gts7MElo9fA=="],
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260118.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260118.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260118.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260118.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260118.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260118.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260118.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260118.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-A+anwzt5RsbCWglYUCAgrolHO9iWLFl2NtRIwDU2IaIxTt0GsFcvaDe+IjswJGHknE0nJ7TS6DeAwjkDD/14og=="],
 
-    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20251218.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4Ew2waH0alZk3fuTIFJ7EsfjIqDj3mNYLa9aTQse6Xnfv16uFEwHbMs4RR1k6qPbPMnyKMC9fpY6f6p1WAPw4A=="],
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260118.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Rr9xUWiT3g104hFgMoVbVSmqK1rQd7VhxwHgNNiPLkznGSc3zewIZ5uBCA93VV2BwC1/ksodwmA1ZYW7Ae2IIg=="],
 
-    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20251218.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-d+6aZW6ig5QdeZzGct6pm0/QoY+cDjUNggG34EefU8m13ThQUCYZ8xMxtSBJsPpFB7AX+iewE2DJtBdgoEbPdg=="],
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260118.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-vtpp39vH6wbp/ONJigF6KM7v3TTu8BAZo7ntXPgpV0YQ5cpXlnh6gQaQyXDjzlZRl/jdr+DS/76easoXeRpsFA=="],
 
-    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20251218.3", "", { "os": "linux", "cpu": "arm" }, "sha512-V62lMa3P4Tqynh2qdIEg9MA43Q19YoVbiG+Am6+TL3JV1gkPNCKr17risKz2GXuNRDJvaxrOm6OTRkceoK8Wgg=="],
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260118.1", "", { "os": "linux", "cpu": "arm" }, "sha512-JpYWxan5wwdZsiZJLWvDr/8gbIThnR1orOZ9Wb8Oc6cHFpYolwnXxAoCPLVnEcAfjnC6cY7WZvY5Dn0gSQ2Asw=="],
 
-    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20251218.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-0LY5RZTvShYYKyxy6ApDqpR0fMUaZUwpNYt9tRUoO4zfTLQdn38xMC4vgRZ3AtYSFX0Y185vLraa+tsdVJcvRw=="],
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260118.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-w32ohkkaBbotPHQttMwzn2l3CO139aTSmIAbDJ1GdbzacDfu1eRHyDaqJ9FpXXF9rkmQxWPIxz8OjpFGoHejQw=="],
 
-    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20251218.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Qi51LQVNiyKcMUnmx2rwSSBWjcxZ+Ec0nkpmeimV0WT1LZJ7ZipJ7KvRRcqLHF2WRk14kknFqDAS83RjdSkPfQ=="],
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260118.1", "", { "os": "linux", "cpu": "x64" }, "sha512-tJuaHEFnKB+V8dkMp9quOjcYs4sbNqwocFyStUN6D6khyYyYDKoKNI68APO4WM0WJ84zMWTyvBDms5uZojftEw=="],
 
-    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20251218.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-y2EQoWU9CfVY3qBUbv0JJqddwsUrz7sRx+08mFg3XZOAMPfq6nwmsGrjNeiYBVwIg7gkZO4BqHL0Ktn6PZ9unA=="],
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260118.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-MhLmNq0OYDRIcWui1g1XaY6tcN4GTzD2rABxwMIpdB+sOtl6YBicoSFk0fToZ+2OOUjjeGwlFzW/LDq540n3HQ=="],
 
-    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20251218.3", "", { "os": "win32", "cpu": "x64" }, "sha512-X1s/tIpHhJP3OL/1qAXnfl8XUoCpv5DmWZhLcFB6F7ZjtH4EmvorrCaeSxdb88/KiL8gcxwipdm69eJb0fZWvA=="],
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260118.1", "", { "os": "win32", "cpu": "x64" }, "sha512-NkXwyQHr/DKbp3BP8CzS4zhOIAY4CmUTYtadr5yyNsTJvuavBH9A4BKjqE/83ZRYB7O5O+n/2z1C5yl7IJp/qQ=="],
 
     "@webassemblyjs/ast": ["@webassemblyjs/ast@1.14.1", "", { "dependencies": { "@webassemblyjs/helper-numbers": "1.13.2", "@webassemblyjs/helper-wasm-bytecode": "1.13.2" } }, "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ=="],
 

--- a/examples/webpack/webpack.config.mjs
+++ b/examples/webpack/webpack.config.mjs
@@ -1,11 +1,9 @@
 // @ts-check
 import path from "node:path";
-import carbonPreprocess from "carbon-preprocess-svelte";
+import { OptimizeCssPlugin, optimizeImports } from "carbon-preprocess-svelte";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import { sveltePreprocess } from "svelte-preprocess";
-
-const { optimizeImports, OptimizeCssPlugin } = carbonPreprocess;
 
 /** @type {"development" | "production"} */
 const NODE_ENV =

--- a/examples/webpack@svelte-5/webpack.config.mjs
+++ b/examples/webpack@svelte-5/webpack.config.mjs
@@ -1,11 +1,9 @@
 // @ts-check
 import path from "node:path";
-import carbonPreprocess from "carbon-preprocess-svelte";
+import { OptimizeCssPlugin, optimizeImports } from "carbon-preprocess-svelte";
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import { sveltePreprocess } from "svelte-preprocess";
-
-const { optimizeImports, OptimizeCssPlugin } = carbonPreprocess;
 
 /** @type {"development" | "production"} */
 const NODE_ENV =

--- a/package.json
+++ b/package.json
@@ -4,12 +4,20 @@
   "license": "Apache-2.0",
   "description": "Svelte preprocessors for the Carbon Design System",
   "author": "Eric Liu (https://github.com/metonym)",
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
   "scripts": {
     "index:components": "bun scripts/index-components.ts",
     "prebuild": "BUILD=true bun run index:components",
-    "build": "tsgo -p tsconfig.build.json",
+    "build": "bun scripts/build.ts",
     "build:prune-package": "bunx culls",
     "test": "bun test",
     "test:e2e": "bun tests/test-e2e.ts",
@@ -18,18 +26,16 @@
     "lint:fix": "biome check --write --unsafe .",
     "upgrade-examples": "bun scripts/upgrade-examples.ts"
   },
-  "dependencies": {
-    "estree-walker": "^2.0.2",
-    "magic-string": "^0.30.17",
-    "postcss": "^8.5.4",
-    "postcss-discard-empty": "^7.0.1"
-  },
   "devDependencies": {
     "@biomejs/biome": "2.3.11",
     "@types/bun": "^1.3.6",
-    "@typescript/native-preview": "^7.0.0-dev.20251218.3",
+    "@typescript/native-preview": "^7.0.0-dev.20260118.1",
     "carbon-components-svelte": "0.98.0",
     "culls": "^0.1.2",
+    "estree-walker": "^2.0.2",
+    "magic-string": "^0.30.17",
+    "postcss": "^8.5.4",
+    "postcss-discard-empty": "^7.0.1",
     "svelte": "^5.46.4",
     "vite": "^7.3.1",
     "webpack": "^5.104.1"

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,0 +1,123 @@
+import { watch } from "node:fs";
+import { $, build } from "bun";
+
+const isWatchMode =
+  process.argv.includes("-w") || process.argv.includes("--watch");
+
+await $`rm -rf dist; mkdir dist`;
+
+async function emitTypeDeclarations() {
+  try {
+    const ts = await import("typescript");
+    const configPath = ts.findConfigFile(
+      ".",
+      ts.sys.fileExists,
+      "tsconfig.build.json",
+    );
+
+    if (!configPath) {
+      throw new Error("Could not find tsconfig.build.json");
+    }
+
+    const configFile = ts.readConfigFile(configPath, ts.sys.readFile);
+    if (configFile.error) {
+      throw new Error(
+        `Failed to read tsconfig: ${ts.formatDiagnostic(
+          configFile.error,
+          ts.createCompilerHost({}),
+        )}`,
+      );
+    }
+
+    const parsedConfig = ts.parseJsonConfigFileContent(
+      configFile.config,
+      ts.sys,
+      "./",
+    );
+
+    const program = ts.createProgram(
+      parsedConfig.fileNames,
+      parsedConfig.options,
+    );
+    const emitResult = program.emit();
+    const allDiagnostics = ts
+      .getPreEmitDiagnostics(program)
+      .concat(emitResult.diagnostics);
+
+    if (allDiagnostics.length > 0) {
+      const host = ts.createCompilerHost(parsedConfig.options);
+      for (const diagnostic of allDiagnostics) {
+        console.error(ts.formatDiagnostic(diagnostic, host));
+      }
+    }
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(error.message);
+    } else {
+      console.error(error);
+    }
+  }
+}
+
+async function buildProject() {
+  const result = await build({
+    entrypoints: ["./src/index.ts"],
+    outdir: "./dist",
+    format: "esm",
+    target: "node",
+    minify: false,
+    sourcemap: false,
+  });
+
+  if (!result.success) {
+    console.error("Build failed");
+    for (const log of result.logs) {
+      console.error(log);
+    }
+    if (!isWatchMode) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  await emitTypeDeclarations();
+  console.log("✓ Build completed");
+}
+
+if (isWatchMode) {
+  console.log("Watching for changes...\n");
+
+  await buildProject();
+
+  let debounceTimer: Timer | null = null;
+  let isBuilding = false;
+
+  const watcher = watch(
+    "./src",
+    { recursive: true },
+    (_eventType, filename) => {
+      if (filename && !isBuilding) {
+        if (debounceTimer) {
+          clearTimeout(debounceTimer);
+        }
+
+        debounceTimer = setTimeout(async () => {
+          console.log(`\nFile changed: ${filename}`);
+          isBuilding = true;
+          await buildProject();
+          isBuilding = false;
+        }, 100);
+      }
+    },
+  );
+
+  setInterval(() => {}, 1000);
+
+  process.on("SIGINT", () => {
+    console.log("\nStopping watch mode...");
+    watcher.close();
+    process.exit(0);
+  });
+} else {
+  await buildProject();
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "emitDeclarationOnly": true,
     "outDir": "dist",
     "target": "ES6",
     "module": "CommonJS"


### PR DESCRIPTION
This modernizes the library by using Bun to build it in ESM format.

**Changes**

- Replace `tsgo` build with custom Bun build script (`scripts/build.ts`)
  - Bundle runtime dependencies
- Convert package to ESM with `"type": "module"` and proper `exports` field

```js
// Before
import carbonPreprocess from "carbon-preprocess-svelte";
const { optimizeImports, OptimizeCssPlugin } = carbonPreprocess;

// After
import { OptimizeCssPlugin, optimizeImports } from "carbon-preprocess-svelte";
```

**Breaking Changes**

Although the `exports` field should maintain compatibility with existing consumers, the library now outputs ESM only.
