### PR TITLE
fix(optimize-imports): use optimistic paths for components

### DIFF
--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -43,8 +43,13 @@ export const optimizeImports: SveltePreprocessor<"script"> = () => {
             switch (import_name) {
               case CarbonSvelte.Components:
                 rewriteImport(s, node, ({ imported, local }) => {
+                  // Use index if available for backwards compatibility with special paths, like .js files.
+                  // Otherwise, use optimistic path for new components.
                   const import_path = components[imported.name]?.path;
-                  if (!import_path) return "";
+                  if (!import_path) {
+                    return `import ${local.name} from "${import_name}/src/${imported.name}/${imported.name}.svelte";`;
+                  }
+
                   return `import ${local.name} from "${import_path}";`;
                 });
                 break;

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -53,12 +53,14 @@ import Airplane2 from "carbon-pictograms-svelte/lib/Airplane.svelte";
 import Airplane3 from "carbon-pictograms-svelte/lib/Airplane.svelte";`);
   });
 
-  test("invalid imports should fail open", () => {
+  test("invalid imports should be optimistic", () => {
     expect(
       preprocess({
         content: "import { NonExistent } from 'carbon-components-svelte'",
       }),
-    ).toEqual("import { NonExistent } from 'carbon-components-svelte'");
+    ).toEqual(
+      'import NonExistent from "carbon-components-svelte/src/NonExistent/NonExistent.svelte";',
+    );
   });
 
   test("mixed imports should be handled correctly", () => {
@@ -151,5 +153,26 @@ import Analytics from "carbon-pictograms-svelte/lib/Analytics.svelte";`);
           import Theme from "carbon-components-svelte/src/Theme/Theme.svelte";
           import type { CarbonTheme } from "carbon-components-svelte/src/Theme/Theme.svelte";
         `);
+  });
+
+  test("backward compatibility with various export patterns", () => {
+    expect(
+      preprocess({
+        content: `import { Accordion, AccordionItem, AccordionSkeleton } from "carbon-components-svelte";
+import { breakpointObserver, breakpoints } from "carbon-components-svelte";
+import { ContainedList, ContainedListItem } from "carbon-components-svelte";
+import { filterTreeNodes, toHierarchy } from "carbon-components-svelte";
+import { NewComponent } from "carbon-components-svelte";`,
+      }),
+    ).toEqual(`import Accordion from "carbon-components-svelte/src/Accordion/Accordion.svelte";
+import AccordionItem from "carbon-components-svelte/src/Accordion/AccordionItem.svelte";
+import AccordionSkeleton from "carbon-components-svelte/src/Accordion/AccordionSkeleton.svelte";
+import breakpointObserver from "carbon-components-svelte/src/Breakpoint/breakpointObserver.js";
+import breakpoints from "carbon-components-svelte/src/Breakpoint/breakpoints.js";
+import ContainedList from "carbon-components-svelte/src/ContainedList/ContainedList.svelte";
+import ContainedListItem from "carbon-components-svelte/src/ContainedList/ContainedListItem.svelte";
+import filterTreeNodes from "carbon-components-svelte/src/utils/filterTreeNodes.js";
+import toHierarchy from "carbon-components-svelte/src/utils/toHierarchy.js";
+import NewComponent from "carbon-components-svelte/src/NewComponent/NewComponent.svelte";`);
   });
 });


### PR DESCRIPTION
Fixes #97

Previously, `optimizeImports` required components to be indexed before they could be used. When new components were added to `carbon-components-svelte`, users had to wait for `carbon-preprocess-svelte` to be re-indexed and released, or manually patch the library. This created a poor developer experience with no mention of the need to patch in release notes (see https://github.com/carbon-design-system/carbon-components-svelte/issues/2486).

The import preprocessor now uses an optimistic approach for components, similar to how icons and pictograms already work. Indexed components use the exact path from the index (maintains backward compatibility for special cases like `.js` utility files).

New components fall back to the optimistic path pattern `carbon-components-svelte/src/{ComponentName}/{ComponentName}.svelte`. If a component doesn't exist, the build system will error appropriately, forwarding the error as expected.