### PR TITLE
chore: add JSDoc comments to plugins, preprocessors, and utils

### DIFF
--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -4,7 +4,18 @@ import type { OptimizeCssOptions } from "./create-optimized-css";
 import { createOptimizedCssAsync } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 
-// Webpack plugin to optimize CSS for Carbon Svelte components.
+/**
+ * Webpack plugin that removes unused Carbon CSS classes from production builds.
+ *
+ * The plugin operates in two phases:
+ * 1. During module processing, it collects all Carbon Svelte component file paths
+ *    by inspecting each module's file dependencies in the `beforeSnapshot` hook.
+ * 2. During asset processing, it uses PostCSS to strip CSS rules that don't match
+ *    any classes used by the collected components.
+ *
+ * This can dramatically reduce CSS bundle size since Carbon's full stylesheet
+ * includes styles for all components, but apps typically use only a subset.
+ */
 class OptimizeCssPlugin {
   private options: OptimizeCssOptions;
 
@@ -35,6 +46,12 @@ class OptimizeCssPlugin {
         const hooks = NormalModule.getCompilationHooks(compilation);
         const ids = new Set<string>();
 
+        /**
+         * The `beforeSnapshot` hook fires after a module is built but before
+         * its snapshot is taken for caching. At this point, `buildInfo.fileDependencies`
+         * contains all files the module depends on, which includes imported Svelte components.
+         * Filter these to find Carbon component paths for the allowlist.
+         */
         hooks.beforeSnapshot.tap(OptimizeCssPlugin.name, ({ buildInfo }) => {
           if (buildInfo?.fileDependencies) {
             for (const id of buildInfo.fileDependencies) {
@@ -45,6 +62,11 @@ class OptimizeCssPlugin {
           }
         });
 
+        /**
+         * Process assets at OPTIMIZE_SIZE stage, which runs after the CSS has been
+         * extracted and concatenated but before final minification. This ensures
+         * that unused rules are removed before any minifier further processes the CSS.
+         */
         compilation.hooks.processAssets.tapPromise(
           {
             name: OptimizeCssPlugin.name,

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -36,9 +36,17 @@ type CreateOptimizedCssOptions = OptimizeCssOptions & {
   ids: Iterable<string>;
 };
 
+/**
+ * Builds an allowlist of CSS class selectors that should be preserved.
+ *
+ * Takes a list of component file paths (e.g., "Button.svelte") and looks up
+ * each component in the pre-generated component-index to find its associated
+ * CSS classes. Returns a Set for O(1) lookups during CSS tree-shaking.
+ *
+ * The ".bx--body" class is always included since it's applied to the document
+ * body by apps using Carbon, but isn't referenced in any component file.
+ */
 function buildAllowlist(ids: Iterable<string>): Set<string> {
-  // List of Carbon classes that must be preserved in the CSS
-  // but that are not referenced in Carbon Svelte components.
   const allowlist = new Set([".bx--body"]);
 
   for (const id of ids) {
@@ -54,13 +62,21 @@ function buildAllowlist(ids: Iterable<string>): Set<string> {
   return allowlist;
 }
 
+/**
+ * Determines whether a CSS rule should be preserved based on its selectors.
+ *
+ * Uses a two-tier matching strategy for performance:
+ * 1. Fast path: O(1) exact match check against the allowlist Set
+ * 2. Slow path: O(n) substring check for BEM-style class variations
+ *
+ * The substring check is necessary because Carbon uses BEM naming conventions
+ * where a parent class like ".bx--btn" may have related selectors like
+ * ".bx--btn--primary" or ".bx--btn__icon" that should also be preserved.
+ */
 function shouldKeepRule(classes: string[], allowlist: Set<string>): boolean {
   for (const name of classes) {
-    // Fast path: exact match.
     if (allowlist.has(name)) return true;
 
-    // Slow path: check if any allowlist item is a substring.
-    // This handles BEM-style suffixes (e.g., .bx--body matches .bx--body__content).
     for (const selector of allowlist) {
       if (name.includes(selector)) return true;
     }
@@ -68,6 +84,13 @@ function shouldKeepRule(classes: string[], allowlist: Set<string>): boolean {
   return false;
 }
 
+/**
+ * Creates the PostCSS plugin pipeline for CSS optimization.
+ *
+ * The pipeline consists of two plugins:
+ * 1. Custom Carbon optimizer - removes unused rules and font-faces
+ * 2. postcss-discard-empty - cleans up any empty rule blocks left behind
+ */
 function createPostcssPlugins(
   allowlist: Set<string>,
   preserveAllIBMFonts: boolean,
@@ -75,16 +98,24 @@ function createPostcssPlugins(
   return [
     {
       postcssPlugin: "postcss-plugin:carbon:optimize-css",
+      /**
+       * Rule visitor that removes CSS rules for unused Carbon components.
+       *
+       * Only processes selectors containing the Carbon prefix (bx--) to avoid
+       * accidentally removing non-Carbon styles. For multi-selector rules
+       * (e.g., ".bx--btn, .bx--link"), each selector is checked individually.
+       */
       Rule(node) {
         const selector = node.selector;
 
-        // Ensure that the selector contains a Carbon prefix.
         if (CARBON_PREFIX.test(selector)) {
-          // Selectors may contain multiple classes, separated by a comma.
+          /**
+           * Parse comma-separated selectors, handling cases where Carbon classes
+           * are prefixed with HTML tags for specificity (e.g., "a.bx--link").
+           * The split on "." extracts the class portion after any tag prefix.
+           */
           const classes = selector.split(",").filter((selectee) => {
             const value = selectee.trim() ?? "";
-            // Some Carbon classes are prefixed with a tag for higher specificity.
-            // E.g., a.bx--header
             const [, rest] = value.split(".");
             return Boolean(rest);
           });
@@ -94,6 +125,15 @@ function createPostcssPlugins(
           }
         }
       },
+      /**
+       * AtRule visitor that removes unused IBM Plex @font-face declarations.
+       *
+       * Carbon's pre-compiled CSS includes @font-face rules for all IBM Plex
+       * variants (weights, styles, languages), but most apps only need a subset.
+       * By default, we preserve only the fonts actually used by Carbon components:
+       * - IBM Plex Sans: weights 300/400/600 in normal style
+       * - IBM Plex Mono: weight 400 in normal style (for code snippets)
+       */
       AtRule(node) {
         if (!preserveAllIBMFonts && node.name === "font-face") {
           const attributes = {
@@ -112,7 +152,6 @@ function createPostcssPlugins(
             }
           });
 
-          // Do not proceed if font is not IBM Plex.
           if (!attributes["font-family"].startsWith("IBM Plex")) {
             return;
           }

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -4,20 +4,45 @@ import type { OptimizeCssOptions } from "./create-optimized-css";
 import { createOptimizedCss } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 
-// Vite plugin (Rollup-compatible) to optimize CSS for Carbon Svelte components.
+/**
+ * Vite/Rollup plugin that removes unused Carbon CSS classes from production builds.
+ *
+ * Unlike the Webpack plugin which uses module dependency tracking, this plugin
+ * collects component IDs during the `transform` hook as modules are processed.
+ * The actual CSS optimization happens in `generateBundle` after all modules
+ * have been transformed and the bundle structure is finalized.
+ *
+ * The plugin is configured with `apply: "build"` and `enforce: "post"` to ensure:
+ * - It only runs during production builds (not dev server)
+ * - It runs after other plugins have finished transforming modules
+ */
 export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
   const verbose = options?.verbose !== false;
+  /**
+   * Set of absolute file paths to Carbon Svelte components used in the app.
+   * Populated during the transform phase, consumed during generateBundle.
+   */
   const ids = new Set<string>();
 
   return {
     name: "vite:carbon:optimize-css",
     apply: "build",
     enforce: "post",
+    /**
+     * The transform hook is called for every module in the build graph.
+     * We don't modify the code here—we just track which Carbon components
+     * are imported so we know which CSS classes to preserve later.
+     */
     transform(_, id) {
       if (isCarbonSvelteImport(id)) {
         ids.add(id);
       }
     },
+    /**
+     * generateBundle runs after all chunks and assets have been created.
+     * We iterate through CSS assets and run PostCSS to remove unused rules.
+     * Mutating `file.source` directly updates the bundle output in-place.
+     */
     async generateBundle(_, bundle) {
       // Skip processing if no Carbon Svelte imports are found.
       if (ids.size === 0) return;

--- a/src/plugins/print-diff.ts
+++ b/src/plugins/print-diff.ts
@@ -2,6 +2,10 @@ import { BITS_DENOM } from "../constants";
 
 const formatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 });
 
+/**
+ * Converts kilobyte values to human-readable format with appropriate units.
+ * Uses decimal system (1 MB = 1000 kB) to match Vite's output conventions.
+ */
 function toHumanReadableSize(size_in_kb: number) {
   if (size_in_kb >= BITS_DENOM) {
     return `${formatter.format(size_in_kb / BITS_DENOM)} MB`;
@@ -14,6 +18,12 @@ function percentageDiff(a: number, b: number) {
   return `${formatter.format(((a - b) / a) * 100)}%`;
 }
 
+/**
+ * Calculates the size of a string in kilobytes.
+ *
+ * Uses Blob to get accurate byte size regardless of character encoding,
+ * which handles multi-byte UTF-8 characters correctly (unlike str.length).
+ */
 function stringSizeInKB(str: string) {
   const blob = new Blob([str], { type: "text/plain" });
   return blob.size / BITS_DENOM;
@@ -23,6 +33,13 @@ function padIfNeeded(a: string, b: string) {
   return a.length > b.length ? a : a.padStart(b.length, " ");
 }
 
+/**
+ * Prints a formatted summary of CSS optimization results to the console.
+ *
+ * Shows the original and optimized file sizes with percentage reduction.
+ * Silently returns if no size change occurred (e.g., when the CSS contains
+ * no Carbon styles or all Carbon components are in use).
+ */
 export function printDiff(props: {
   original_css: Uint8Array | Buffer | string;
   optimized_css: string;
@@ -33,6 +50,10 @@ export function printDiff(props: {
   const original_size = stringSizeInKB(original_css.toString());
   const optimized_size = stringSizeInKB(optimized_css);
 
+  /**
+   * Skip output when sizes are equal—this indicates either no Carbon CSS
+   * was present, or all detected components' styles were preserved.
+   */
   if (original_size === optimized_size) {
     return;
   }


### PR DESCRIPTION
Replace brief inline comments with JSDoc blocks that document purpose, behavior, and integration points (e.g., hook phases, BEM matching). Improves maintainability and IDE hover docs; no behavior change.