### PR TITLE
refactor(optimize-imports): use MagicString `update()` and chain `replace()`

### DIFF
--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -24,7 +24,7 @@ function rewriteImport(
     }
   }
 
-  if (content) s.overwrite(node.start, node.end, content.trimEnd());
+  if (content) s.update(node.start, node.end, content.trimEnd());
 }
 
 /**
@@ -93,8 +93,7 @@ export const optimizeImports: SveltePreprocessor<"script"> = () => {
         },
       });
 
-      s.replace(SCRIPT_OPEN_TAG_REGEX, "");
-      s.replace(SCRIPT_CLOSE_TAG_REGEX, "");
+      s.replace(SCRIPT_OPEN_TAG_REGEX, "").replace(SCRIPT_CLOSE_TAG_REGEX, "");
 
       return {
         code: s.toString(),


### PR DESCRIPTION
Prefer MagicString's update() over overwrite() for AST-based replacements (avoids overwriting appended content). Chain the two script-tag replace() calls for clearer, idiomatic usage.