### PR TITLE
build: minify bundle

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -65,8 +65,7 @@ async function buildProject() {
     outdir: "./dist",
     format: "esm",
     target: "node",
-    minify: false,
-    sourcemap: false,
+    minify: true,
   });
 
   if (!result.success) {


### PR DESCRIPTION
This uses [Bun](https://bun.sh/docs/bundler) to bundle the library. This enables minification as a further optimization. A smaller package size translates to faster installs (smaller tarball) and execution.

| Metric         | Before  | After   | Reduction | % smaller |
|----------------|---------|---------|-----------|-----------|
| Packed size    | 215.34 KB | 176.00 KB | 39.34 KB | 18.3% |
| Unpacked size  | 1.19 MB | 0.68 MB | 0.51 MB (510 KB) | 42.9% |
