### PR TITLE
fix(optimize-css): add `silent` option, deprecate `verbose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,11 @@ export default {
 ```ts
 optimizeCss({
   /**
-   * By default, the plugin will print the size
-   * difference between the original and optimized CSS.
-   *
-   * Set to `false` to disable verbose logging.
-   * @default true
+   * Set to `true` to suppress the size difference
+   * logging between original and optimized CSS.
+   * @default false
    */
-  verbose: false,
+  silent: true,
 
   /**
    * By default, pre-compiled Carbon StyleSheets ship `@font-face` rules

--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -1,7 +1,7 @@
 import type { Compiler } from "webpack";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
-import { createOptimizedCssAsync } from "./create-optimized-css";
+import { createOptimizedCssAsync, isSilent } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 
 /**
@@ -21,7 +21,6 @@ class OptimizeCssPlugin {
 
   public constructor(options?: OptimizeCssOptions) {
     this.options = {
-      verbose: true,
       preserveAllIBMFonts: false,
       ...options,
     };
@@ -95,7 +94,7 @@ class OptimizeCssPlugin {
             for (const { id, original_css, optimized_css } of results) {
               compilation.updateAsset(id, new RawSource(optimized_css));
 
-              if (this.options.verbose) {
+              if (!isSilent(this.options)) {
                 printDiff({ original_css, optimized_css, id });
               }
             }

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -7,11 +7,16 @@ import { CARBON_PREFIX } from "../constants";
 
 export type OptimizeCssOptions = {
   /**
-   * By default, the plugin will print the size
-   * difference between the original and optimized CSS.
-   *
+   * Set to `true` to suppress the size difference
+   * logging between original and optimized CSS.
+   * @default false
+   */
+  silent?: boolean;
+
+  /**
    * Set to `false` to disable verbose logging.
    * @default true
+   * @deprecated Use `silent` instead.
    */
   verbose?: boolean;
 
@@ -30,6 +35,16 @@ export type OptimizeCssOptions = {
    */
   preserveAllIBMFonts?: boolean;
 };
+
+/**
+ * Resolves the `silent` / `verbose` options into a single boolean.
+ * `silent` takes precedence when provided; otherwise falls back
+ * to inverting `verbose` (which defaults to `true`).
+ */
+export function isSilent(options?: OptimizeCssOptions): boolean {
+  if (options?.silent !== undefined) return options.silent;
+  return options?.verbose === false;
+}
 
 type CreateOptimizedCssOptions = OptimizeCssOptions & {
   source: Uint8Array | string;

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from "vite";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
-import { createOptimizedCss } from "./create-optimized-css";
+import { createOptimizedCss, isSilent } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 
 /**
@@ -17,7 +17,7 @@ import { printDiff } from "./print-diff";
  * - It runs after other plugins have finished transforming modules
  */
 export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
-  const verbose = options?.verbose !== false;
+  const silent = isSilent(options);
   /**
    * Set of absolute file paths to Carbon Svelte components used in the app.
    * Populated during the transform phase, consumed during generateBundle.
@@ -60,7 +60,7 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
 
           file.source = optimized_css;
 
-          if (verbose) {
+          if (!silent) {
             printDiff({ original_css, optimized_css, id });
           }
         }

--- a/tests/OptimizeCssPlugin.test.ts
+++ b/tests/OptimizeCssPlugin.test.ts
@@ -67,19 +67,18 @@ describe("OptimizeCssPlugin", () => {
     const plugin = new OptimizeCssPlugin();
     // @ts-expect-error – options is private
     expect(plugin.options).toEqual({
-      verbose: true,
       preserveAllIBMFonts: false,
     } as const);
   });
 
   test("constructor respects provided options", () => {
     const plugin = new OptimizeCssPlugin({
-      verbose: false,
+      silent: true,
       preserveAllIBMFonts: true,
     });
     // @ts-expect-error – options is private
     expect(plugin.options).toEqual({
-      verbose: false,
+      silent: true,
       preserveAllIBMFonts: true,
     });
   });
@@ -149,9 +148,9 @@ describe("OptimizeCssPlugin", () => {
     );
   });
 
-  test("respects verbose option for printing diff", async () => {
+  test("respects silent option for printing diff", async () => {
     const consoleSpy = jest.spyOn(console, "log").mockImplementation();
-    const plugin = new OptimizeCssPlugin({ verbose: true });
+    const plugin = new OptimizeCssPlugin({ silent: false });
     const carbonComponent = `node_modules/${CarbonSvelte.Components}/Button.svelte`;
 
     const mockCompiler = createMockCompiler({


### PR DESCRIPTION
`silent: true` reads more naturally than `verbose: false`.

Both options are supported via `isSilent()` resolver, with `silent` taking precedence for backward compatibility.