### PR TITLE
fix(optimize-css): pass PostCSS `from` option to silence "Without from option" warning

### DIFF
--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -86,6 +86,7 @@ class OptimizeCssPlugin {
                     ? original_css.toString()
                     : original_css,
                   ids,
+                  from: id,
                 });
                 return { id, original_css, optimized_css };
               }),

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -49,6 +49,8 @@ export function isSilent(options?: OptimizeCssOptions): boolean {
 type CreateOptimizedCssOptions = OptimizeCssOptions & {
   source: Uint8Array | string;
   ids: Iterable<string>;
+  /** PostCSS `from` option. Pass asset/chunk path when available, or omit for `undefined`. */
+  from?: string | undefined;
 };
 
 /**
@@ -198,6 +200,7 @@ export function createOptimizedCss(options: CreateOptimizedCssOptions): string {
 
   return postcss(createPostcssPlugins(allowlist, preserveAllIBMFonts)).process(
     source,
+    { from: options.from },
   ).css;
 }
 
@@ -210,7 +213,7 @@ export async function createOptimizedCssAsync(
 
   const result = await postcss(
     createPostcssPlugins(allowlist, preserveAllIBMFonts),
-  ).process(source);
+  ).process(source, { from: options.from });
 
   return result.css;
 }

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -56,6 +56,7 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
             ...options,
             source: original_css,
             ids,
+            from: id,
           });
 
           file.source = optimized_css;


### PR DESCRIPTION
The `OptimizeCssPlugin` and the shared CSS optimization path were calling PostCSS without the `from` option, which can trigger a warning in development builds:

```
Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.
```
The fix passes `from` explicitly: the asset/chunk path when available (Webpack, Vite/Rollup), or `undefined` when not (e.g., tests), so the warning is suppressed, and behavior is explicit. Passing the real path also improves source map accuracy.