### PR TITLE
feat(optimize-css): add `experimental.strict` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,28 @@ optimizeCss({
    * @default false
    */
   preserveAllIBMFonts: true,
+
+  /**
+   * Experimental. Enables stricter CSS tree-shaking that can drastically
+   * reduce output size compared to the default baseline, depending on which
+   * Carbon components you import. Small bundles that only use a handful of
+   * components tend to see the largest gains.
+   *
+   * Compared to the default matcher, `strict`:
+   * - Prunes individual selectors from comma-separated lists instead of
+   *   keeping the entire rule when any selector matches
+   * - Requires every Carbon class in a compound selector to match when only
+   *   shared modifiers (e.g. `.bx--skeleton`) hit, so importing Button no
+   *   longer pulls in Tabs skeleton styles
+   * - Drops flatpickr and legacy single-hyphen `bx-` rules unless DatePicker
+   *   (or similar) is in the bundle
+   * - Uses parenthesis-aware selector parsing for `:is()` and similar
+   *
+   * @default false
+   */
+  experimental: {
+    strict: true,
+  },
 });
 ```
 

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -4,6 +4,10 @@ import postcss from "postcss";
 import discardEmpty from "postcss-discard-empty";
 import { components } from "../component-index";
 import { CARBON_PREFIX } from "../constants";
+import {
+  optimizeStrictAtRule,
+  optimizeStrictRule,
+} from "./strict-css-optimizer";
 
 export type OptimizeCssOptions = {
   /**
@@ -34,6 +38,28 @@ export type OptimizeCssOptions = {
    * @default false
    */
   preserveAllIBMFonts?: boolean;
+
+  experimental?: {
+    /**
+     * Enables stricter CSS tree-shaking. Compared to the default baseline,
+     * this can drastically reduce output size depending on which Carbon
+     * components you import — especially for small bundles that only use a
+     * handful of components.
+     *
+     * Improvements over the default matcher:
+     * - Prunes individual selectors from comma-separated lists instead of
+     *   keeping the entire rule when any selector matches
+     * - Requires every Carbon class in a compound selector to match the
+     *   allowlist when only shared modifiers (e.g. `.bx--skeleton`) hit,
+     *   so importing Button no longer pulls in Tabs skeleton styles
+     * - Drops flatpickr and legacy single-hyphen `bx-` rules unless
+     *   DatePicker (or similar) is in the bundle
+     * - Uses parenthesis-aware selector parsing for `:is()` and similar
+     *
+     * @default false
+     */
+    strict?: boolean;
+  };
 };
 
 /**
@@ -46,6 +72,10 @@ export function isSilent(options?: OptimizeCssOptions): boolean {
   return options?.verbose === false;
 }
 
+function isStrict(options?: OptimizeCssOptions): boolean {
+  return options?.experimental?.strict === true;
+}
+
 type CreateOptimizedCssOptions = OptimizeCssOptions & {
   source: Uint8Array | string;
   ids: Iterable<string>;
@@ -54,20 +84,26 @@ type CreateOptimizedCssOptions = OptimizeCssOptions & {
 };
 
 /**
- * Builds an allowlist of CSS class selectors that should be preserved.
+ * Build the class allowlist from bundled component paths and whether flatpickr
+ * CSS should stay (any DatePicker import).
  *
- * Takes a list of component file paths (e.g., "Button.svelte") and looks up
- * each component in the pre-generated component-index to find its associated
- * CSS classes. Returns a Set for O(1) lookups during CSS tree-shaking.
- *
- * The ".bx--body" class is always included since it's applied to the document
- * body by apps using Carbon, but isn't referenced in any component file.
+ * Paths like "Button.svelte" map through component-index to `.bx--*` classes.
+ * `.bx--body` is always kept; apps set it on `<body>` but no component file
+ * references it.
  */
-function buildAllowlist(ids: Iterable<string>): Set<string> {
+function buildUsage(ids: Iterable<string>): {
+  allowlist: Set<string>;
+  preserveFlatpickr: boolean;
+} {
   const allowlist = new Set([".bx--body"]);
+  let preserveFlatpickr = false;
 
   for (const id of ids) {
     const { name } = path.parse(id);
+
+    if (name === "DatePicker") {
+      preserveFlatpickr = true;
+    }
 
     if (name in components) {
       for (const cls of components[name].classes) {
@@ -76,22 +112,11 @@ function buildAllowlist(ids: Iterable<string>): Set<string> {
     }
   }
 
-  return allowlist;
+  return { allowlist, preserveFlatpickr };
 }
 
-/**
- * Determines whether a CSS rule should be preserved based on its selectors.
- *
- * Uses a two-tier matching strategy for performance:
- * 1. Fast path: O(1) exact match check against the allowlist Set
- * 2. Slow path: O(n) substring check for BEM-style class variations
- *
- * The substring check is necessary because Carbon uses BEM naming conventions
- * where a parent class like ".bx--btn" may have related selectors like
- * ".bx--btn--primary" or ".bx--btn__icon" that should also be preserved.
- */
-function shouldKeepRule(classes: string[], allowlist: Set<string>): boolean {
-  for (const name of classes) {
+function shouldKeepRule(selectors: string[], allowlist: Set<string>): boolean {
+  for (const name of selectors) {
     if (allowlist.has(name)) return true;
 
     for (const selector of allowlist) {
@@ -111,6 +136,8 @@ function shouldKeepRule(classes: string[], allowlist: Set<string>): boolean {
 function createPostcssPlugins(
   allowlist: Set<string>,
   preserveAllIBMFonts: boolean,
+  preserveFlatpickr: boolean,
+  strict: boolean,
 ): AcceptedPlugin[] {
   return [
     {
@@ -123,24 +150,24 @@ function createPostcssPlugins(
        * (e.g., ".bx--btn, .bx--link"), each selector is checked individually.
        */
       Rule(node) {
-        const selector = node.selector;
+        if (!strict) {
+          const selector = node.selector;
 
-        if (CARBON_PREFIX.test(selector)) {
-          /**
-           * Parse comma-separated selectors, handling cases where Carbon classes
-           * are prefixed with HTML tags for specificity (e.g., "a.bx--link").
-           * The split on "." extracts the class portion after any tag prefix.
-           */
-          const classes = selector.split(",").filter((selectee) => {
-            const value = selectee.trim() ?? "";
-            const [, rest] = value.split(".");
-            return Boolean(rest);
-          });
+          if (CARBON_PREFIX.test(selector)) {
+            const selectors = selector.split(",").filter((selectee) => {
+              const value = selectee.trim() ?? "";
+              const [, rest] = value.split(".");
+              return Boolean(rest);
+            });
 
-          if (!shouldKeepRule(classes, allowlist)) {
-            node.remove();
+            if (!shouldKeepRule(selectors, allowlist)) {
+              node.remove();
+            }
           }
+          return;
         }
+
+        optimizeStrictRule(node, { allowlist, preserveFlatpickr });
       },
       /**
        * AtRule visitor that removes unused IBM Plex @font-face declarations.
@@ -152,6 +179,11 @@ function createPostcssPlugins(
        * - IBM Plex Mono: weight 400 in normal style (for code snippets)
        */
       AtRule(node) {
+        if (strict) {
+          optimizeStrictAtRule(node, { preserveFlatpickr });
+          if (!node.parent) return;
+        }
+
         if (!preserveAllIBMFonts && node.name === "font-face") {
           const attributes = {
             "font-family": "",
@@ -196,12 +228,17 @@ function createPostcssPlugins(
 export function createOptimizedCss(options: CreateOptimizedCssOptions): string {
   const { source, ids } = options;
   const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
-  const allowlist = buildAllowlist(ids);
+  const strict = isStrict(options);
+  const { allowlist, preserveFlatpickr } = buildUsage(ids);
 
-  return postcss(createPostcssPlugins(allowlist, preserveAllIBMFonts)).process(
-    source,
-    { from: options.from },
-  ).css;
+  return postcss(
+    createPostcssPlugins(
+      allowlist,
+      preserveAllIBMFonts,
+      preserveFlatpickr,
+      strict,
+    ),
+  ).process(source, { from: options.from }).css;
 }
 
 export async function createOptimizedCssAsync(
@@ -209,10 +246,16 @@ export async function createOptimizedCssAsync(
 ): Promise<string> {
   const { source, ids } = options;
   const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
-  const allowlist = buildAllowlist(ids);
+  const strict = isStrict(options);
+  const { allowlist, preserveFlatpickr } = buildUsage(ids);
 
   const result = await postcss(
-    createPostcssPlugins(allowlist, preserveAllIBMFonts),
+    createPostcssPlugins(
+      allowlist,
+      preserveAllIBMFonts,
+      preserveFlatpickr,
+      strict,
+    ),
   ).process(source, { from: options.from });
 
   return result.css;

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -1,0 +1,193 @@
+import type { AtRule, Rule } from "postcss";
+import { components } from "../component-index";
+import { CARBON_PREFIX } from "../constants";
+
+const CARBON_CLASS = /\.bx--[A-Za-z0-9_-]+/g;
+const LEGACY_CARBON_CLASS = /\.bx-(?!-)[A-Za-z0-9_-]+/g;
+const LEGACY_CARBON_PREFIX = /bx-(?!-)/;
+const BEM_PREFIXES = ["--", "__"];
+const FLATPICKR_CLASS_NAMES = [
+  "dayContainer",
+  "numInputWrapper",
+  "numInput",
+  "cur-month",
+  "arrowUp",
+  "arrowDown",
+  "prevMonthDay",
+  "nextMonthDay",
+  "startRange",
+  "endRange",
+  "inRange",
+  "noCalendar",
+  "hasTime",
+  "hasWeeks",
+  "showTimeInput",
+  "slideLeft",
+  "slideLeftNew",
+  "slideRight",
+  "slideRightNew",
+];
+const FLATPICKR_SELECTOR = new RegExp(
+  `\\.(?:flatpickr-[A-Za-z0-9_-]+|${FLATPICKR_CLASS_NAMES.join("|")})(?![A-Za-z0-9_-])`,
+);
+const FLATPICKR_KEYFRAMES = new Set(["fpFadeInDown"]);
+const SHARED_CLASSES = getSharedClasses();
+
+export type StrictCssOptimizerOptions = {
+  allowlist: Set<string>;
+  preserveFlatpickr: boolean;
+};
+
+function getSharedClasses(): Set<string> {
+  const counts = new Map<string, number>();
+
+  for (const component of Object.values(components)) {
+    for (const cls of new Set(component.classes)) {
+      counts.set(cls, (counts.get(cls) ?? 0) + 1);
+    }
+  }
+
+  return new Set(
+    [...counts].filter(([, count]) => count > 1).map(([cls]) => cls),
+  );
+}
+
+/**
+ * Split on commas at parenthesis depth 0 so `:is(.a, .b)` stays one selector.
+ */
+function splitSelectorList(selector: string): string[] {
+  const selectors: string[] = [];
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i < selector.length; i++) {
+    const char = selector[i];
+
+    if (char === "(") {
+      depth++;
+    } else if (char === ")") {
+      depth = Math.max(0, depth - 1);
+    } else if (char === "," && depth === 0) {
+      selectors.push(selector.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+
+  selectors.push(selector.slice(start).trim());
+
+  return selectors.filter(Boolean);
+}
+
+function getCarbonClasses(selector: string): string[] {
+  const classes = selector.match(CARBON_CLASS) ?? [];
+  const legacyClasses = (selector.match(LEGACY_CARBON_CLASS) ?? []).map((cls) =>
+    cls.replace(".bx-", ".bx--"),
+  );
+
+  return [...new Set([...classes, ...legacyClasses])];
+}
+
+type AllowlistMatch = { matched: true; shared: boolean } | { matched: false };
+
+function matchesAllowlist(
+  name: string,
+  allowlist: Set<string>,
+): AllowlistMatch {
+  if (allowlist.has(name)) {
+    return { matched: true, shared: SHARED_CLASSES.has(name) };
+  }
+
+  for (const selector of allowlist) {
+    const shared = SHARED_CLASSES.has(selector);
+    if (selector.endsWith("-") && name.startsWith(selector)) {
+      return { matched: true, shared };
+    }
+
+    if (shared) continue;
+
+    if (
+      BEM_PREFIXES.some((prefix) => name.startsWith(`${selector}${prefix}`))
+    ) {
+      return { matched: true, shared: false };
+    }
+  }
+
+  return { matched: false };
+}
+
+/**
+ * Whether to keep this selector in strict mode.
+ *
+ * Allowlist hits use Set lookup; otherwise prefix-match BEM children
+ * (`.bx--btn--primary`, `.bx--btn__icon`).
+ *
+ * Shared classes like `.bx--skeleton` only count if every Carbon class in
+ * the selector is allowed, so Button imports do not pull in Tabs skeleton rules.
+ */
+function shouldKeepSelector(selector: string, allowlist: Set<string>): boolean {
+  const classes = getCarbonClasses(selector);
+  if (classes.length === 0) return true;
+
+  let hasMatch = false;
+
+  for (const name of classes) {
+    const match = matchesAllowlist(name, allowlist);
+    if (!match.matched) continue;
+    if (!match.shared) return true;
+    hasMatch = true;
+  }
+
+  return (
+    hasMatch &&
+    classes.every((name) => matchesAllowlist(name, allowlist).matched)
+  );
+}
+
+export function optimizeStrictRule(
+  node: Rule,
+  options: StrictCssOptimizerOptions,
+): void {
+  const { allowlist, preserveFlatpickr } = options;
+  const selector = node.selector;
+
+  if (
+    !(
+      CARBON_PREFIX.test(selector) ||
+      LEGACY_CARBON_PREFIX.test(selector) ||
+      FLATPICKR_SELECTOR.test(selector)
+    )
+  ) {
+    return;
+  }
+
+  const selectors = splitSelectorList(selector);
+  const keptSelectors = selectors.filter((selectee) => {
+    if (FLATPICKR_SELECTOR.test(selectee) && !preserveFlatpickr) {
+      return false;
+    }
+
+    return (
+      !(CARBON_PREFIX.test(selectee) || LEGACY_CARBON_PREFIX.test(selectee)) ||
+      shouldKeepSelector(selectee, allowlist)
+    );
+  });
+
+  if (keptSelectors.length === 0) {
+    node.remove();
+  } else if (keptSelectors.length < selectors.length) {
+    node.selector = keptSelectors.join(", ");
+  }
+}
+
+export function optimizeStrictAtRule(
+  node: AtRule,
+  options: Pick<StrictCssOptimizerOptions, "preserveFlatpickr">,
+): void {
+  if (
+    !options.preserveFlatpickr &&
+    node.name === "keyframes" &&
+    FLATPICKR_KEYFRAMES.has(node.params)
+  ) {
+    node.remove();
+  }
+}

--- a/tests/OptimizeCssPlugin.test.ts
+++ b/tests/OptimizeCssPlugin.test.ts
@@ -75,11 +75,13 @@ describe("OptimizeCssPlugin", () => {
     const plugin = new OptimizeCssPlugin({
       silent: true,
       preserveAllIBMFonts: true,
+      experimental: { strict: true },
     });
     // @ts-expect-error – options is private
     expect(plugin.options).toEqual({
       silent: true,
       preserveAllIBMFonts: true,
+      experimental: { strict: true },
     });
   });
 
@@ -169,5 +171,28 @@ describe("OptimizeCssPlugin", () => {
 
     expect(consoleSpy).toHaveBeenCalled();
     consoleSpy.mockRestore();
+  });
+
+  test("passes experimental strict option to CSS optimization", async () => {
+    const plugin = new OptimizeCssPlugin({
+      silent: true,
+      experimental: { strict: true },
+    });
+    const carbonComponent = `node_modules/${CarbonSvelte.Components}/Button.svelte`;
+    const cssContent = `.bx--btn { color: blue }
+.bx-slider-text-input { appearance: textfield }`;
+
+    const mockCompiler = createMockCompiler({
+      assets: {
+        "styles.css": { source: () => cssContent },
+      },
+      fileDependencies: [carbonComponent],
+    });
+
+    plugin.apply(asCompiler(mockCompiler));
+    await mockCompiler.waitForProcessAssets();
+
+    const [, asset] = mockCompiler.compilation.updateAsset.mock.calls[0];
+    expect(asset.source()).toEqual(".bx--btn { color: blue }");
   });
 });

--- a/tests/create-optimized-css.test.ts
+++ b/tests/create-optimized-css.test.ts
@@ -1,6 +1,8 @@
 import { createOptimizedCss } from "carbon-preprocess-svelte/plugins/create-optimized-css";
 
 describe("create-optimized-css", () => {
+  const strict = { experimental: { strict: true } } as const;
+
   test("removes unused selectors", () => {
     const result = createOptimizedCss({
       source: `* { box-sizing: border-box }
@@ -159,13 +161,111 @@ button.bx--btn.bx--btn--primary { color: white }`,
 button.bx--btn.bx--btn--primary { color: white }`);
   });
 
-  test("avoids false positives", () => {
+  test("preserves mixed selector lists by default", () => {
     const result = createOptimizedCss({
       source: ".bx--btn, .bx--btn--primary, .bx--unused { color: white }",
       ids: ["Button"],
     });
     expect(result).toEqual(
       ".bx--btn, .bx--btn--primary, .bx--unused { color: white }",
+    );
+  });
+
+  test("removes unused selectors from mixed selector lists in strict mode", () => {
+    const result = createOptimizedCss({
+      ...strict,
+      source: ".bx--btn, .bx--btn--primary, .bx--unused { color: white }",
+      ids: ["Button"],
+    });
+    expect(result).toEqual(".bx--btn, .bx--btn--primary { color: white }");
+  });
+
+  test("does not preserve unrelated component skeleton styles in strict mode", () => {
+    const result = createOptimizedCss({
+      ...strict,
+      source: `.bx--btn.bx--skeleton { width: 9rem }
+.bx--tabs.bx--skeleton { cursor: default }
+.bx--tabs.bx--skeleton .bx--tabs__nav-link span:before { animation: skeleton 3s infinite }
+.bx--structured-list.bx--skeleton span { height: 1rem }
+.bx--skeleton__text { height: 1rem }
+.bx--skeleton { position: relative }`,
+      ids: ["Button"],
+    });
+    expect(result).toEqual(`.bx--btn.bx--skeleton { width: 9rem }
+.bx--skeleton { position: relative }`);
+  });
+
+  test("preserves selectors for explicit skeleton components", () => {
+    const result = createOptimizedCss({
+      ...strict,
+      source: `.bx--skeleton__text { height: 1rem }
+.bx--skeleton__heading { height: 1.5rem }
+.bx--skeleton__placeholder { width: 100% }
+.bx--tabs.bx--skeleton { cursor: default }`,
+      ids: ["SkeletonText"],
+    });
+    expect(result).toEqual(`.bx--skeleton__text { height: 1rem }
+.bx--skeleton__heading { height: 1.5rem }`);
+  });
+
+  test("keeps non-Carbon selectors when pruning mixed selector lists", () => {
+    const result = createOptimizedCss({
+      ...strict,
+      source: "button, .bx--unused { color: red }",
+      ids: ["Button"],
+    });
+    expect(result).toEqual("button { color: red }");
+  });
+
+  test("preserves flatpickr selectors by default", () => {
+    const source = `.flatpickr-calendar { visibility: hidden }
+.numInputWrapper:hover { background-color: #353535 }`;
+
+    expect(createOptimizedCss({ source, ids: ["Button"] })).toEqual(source);
+  });
+
+  test("removes flatpickr selectors unless DatePicker is used in strict mode", () => {
+    const result = createOptimizedCss({
+      ...strict,
+      source: `@keyframes fpFadeInDown { from { opacity: 0 } to { opacity: 1 } }
+.flatpickr-calendar { visibility: hidden }
+.flatpickr-calendar.open, .flatpickr-calendar.inline { visibility: inherit }
+.numInputWrapper:hover { background-color: #353535 }
+.flatpickr-current-month .cur-month { margin: 0 .25rem }
+button, .flatpickr-day.selected { color: red }`,
+      ids: ["Button"],
+    });
+    expect(result).toEqual("button { color: red }");
+  });
+
+  test("preserves flatpickr selectors when DatePicker is used", () => {
+    const result = createOptimizedCss({
+      ...strict,
+      source: `@keyframes fpFadeInDown { from { opacity: 0 } to { opacity: 1 } }
+.flatpickr-calendar { visibility: hidden }
+.numInputWrapper:hover { background-color: #353535 }
+.flatpickr-current-month .cur-month { margin: 0 .25rem }`,
+      ids: ["DatePicker"],
+    });
+    expect(
+      result,
+    ).toEqual(`@keyframes fpFadeInDown { from { opacity: 0 } to { opacity: 1 } }
+.flatpickr-calendar { visibility: hidden }
+.numInputWrapper:hover { background-color: #353535 }
+.flatpickr-current-month .cur-month { margin: 0 .25rem }`);
+  });
+
+  test("matches legacy single-hyphen Carbon selectors against the allowlist", () => {
+    const source = `.bx-slider-text-input { appearance: textfield }
+.bx-slider-text-input::-webkit-outer-spin-button { display: none }
+.bx-slider-text-input::-webkit-inner-spin-button { display: none }`;
+
+    expect(createOptimizedCss({ source, ids: ["Button"] })).toEqual(source);
+    expect(createOptimizedCss({ ...strict, source, ids: ["Button"] })).toEqual(
+      "",
+    );
+    expect(createOptimizedCss({ ...strict, source, ids: ["Slider"] })).toEqual(
+      source,
     );
   });
 


### PR DESCRIPTION
Add an experimental approach that can vastly improve the pruning of unused Carbon-specific classes.