### PR TITLE
chore(examples): enable `experimental.strict` in `optimizeCss`

### DIFF
--- a/examples/rollup/rollup.config.js
+++ b/examples/rollup/rollup.config.js
@@ -25,6 +25,6 @@ export default {
     commonjs(),
     css({ output: "bundle.css" }),
     production && terser(),
-    production && optimizeCss(),
+    production && optimizeCss({ experimental: { strict: true } }),
   ],
 };

--- a/examples/sveltekit/vite.config.js
+++ b/examples/sveltekit/vite.config.js
@@ -3,7 +3,7 @@ import { optimizeCss } from "carbon-preprocess-svelte";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [sveltekit(), optimizeCss()],
+  plugins: [sveltekit(), optimizeCss({ experimental: { strict: true } })],
 
   // Optional, but recommended for even faster cold starts.
   // Instruct Vite to exclude packages that `optimizeImports` will resolve.

--- a/examples/vite/vite.config.ts
+++ b/examples/vite/vite.config.ts
@@ -7,7 +7,7 @@ export default {
     svelte({
       preprocess: [vitePreprocess(), optimizeImports()],
     }),
-    optimizeCss(),
+    optimizeCss({ experimental: { strict: true } }),
   ],
 
   // Optional, but recommended for even faster cold starts.

--- a/examples/vite@svelte-5/vite.config.ts
+++ b/examples/vite@svelte-5/vite.config.ts
@@ -10,7 +10,7 @@ export default {
     svelte({
       preprocess: [vitePreprocess(), optimizeImports()],
     }),
-    optimizeCss(),
+    optimizeCss({ experimental: { strict: true } }),
   ],
 
   // Optional, but recommended for even faster cold starts.

--- a/examples/webpack/webpack.config.mjs
+++ b/examples/webpack/webpack.config.mjs
@@ -49,7 +49,7 @@ export default {
   },
   mode: NODE_ENV,
   plugins: [
-    new OptimizeCssPlugin(),
+    new OptimizeCssPlugin({ experimental: { strict: true } }),
     new MiniCssExtractPlugin({
       filename: PROD ? "[name].[chunkhash].css" : "[name].css",
     }),

--- a/examples/webpack@svelte-5/webpack.config.mjs
+++ b/examples/webpack@svelte-5/webpack.config.mjs
@@ -49,7 +49,7 @@ export default {
   },
   mode: NODE_ENV,
   plugins: [
-    new OptimizeCssPlugin(),
+    new OptimizeCssPlugin({ experimental: { strict: true } }),
     new MiniCssExtractPlugin({
       filename: PROD ? "[name].[chunkhash].css" : "[name].css",
     }),

--- a/tests/__snapshots__/e2e.json
+++ b/tests/__snapshots__/e2e.json
@@ -2,37 +2,37 @@
   "rollup": {
     "file": "bundle.css",
     "before_kb": 664.74,
-    "after_kb": 159.5,
-    "reduction_percent": 76.01
+    "after_kb": 137.13,
+    "reduction_percent": 79.37
   },
   "sveltekit": {
     "file": "_app/immutable/assets/2.C-*.css",
     "before_kb": 617.52,
-    "after_kb": 66.4,
-    "reduction_percent": 89.25
+    "after_kb": 45.71,
+    "reduction_percent": 92.6
   },
   "vite": {
     "file": "assets/index-*.css",
     "before_kb": 654.96,
-    "after_kb": 74.16,
-    "reduction_percent": 88.68
+    "after_kb": 52.16,
+    "reduction_percent": 92.04
   },
   "vite@svelte-5": {
     "file": "assets/index-*.css",
     "before_kb": 617.52,
-    "after_kb": 66.4,
-    "reduction_percent": 89.25
+    "after_kb": 45.71,
+    "reduction_percent": 92.6
   },
   "webpack": {
     "file": "build/bundle.*.css",
     "before_kb": 664.74,
-    "after_kb": 159.5,
-    "reduction_percent": 76.01
+    "after_kb": 137.13,
+    "reduction_percent": 79.37
   },
   "webpack@svelte-5": {
     "file": "build/bundle.*.css",
     "before_kb": 664.74,
-    "after_kb": 159.5,
-    "reduction_percent": 76.01
+    "after_kb": 137.13,
+    "reduction_percent": 79.37
   }
 }


### PR DESCRIPTION
Now that #123 is implemented, enable the mode in the examples to start dogfooding.

The examples use the DataTable (already a huge component), so the reductions are modest.