### PR TITLE
fix(optimize-css): suppress diff log when nothing is pruned

### DIFF
--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -1,7 +1,7 @@
 import type { Compiler } from "webpack";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
-import { createOptimizedCssAsync, isSilent } from "./create-optimized-css";
+import { isSilent, optimizeCssWithReportAsync } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 
 /**
@@ -80,22 +80,28 @@ class OptimizeCssPlugin {
             const results = await Promise.all(
               cssAssetIds.map(async (id) => {
                 const original_css = assets[id].source();
-                const optimized_css = await createOptimizedCssAsync({
-                  ...this.options,
-                  source: Buffer.isBuffer(original_css)
-                    ? original_css.toString()
-                    : original_css,
-                  ids,
-                  from: id,
-                });
-                return { id, original_css, optimized_css };
+                const { css: optimized_css, removed } =
+                  await optimizeCssWithReportAsync({
+                    ...this.options,
+                    source: Buffer.isBuffer(original_css)
+                      ? original_css.toString()
+                      : original_css,
+                    ids,
+                    from: id,
+                  });
+                return { id, original_css, optimized_css, removed };
               }),
             );
 
-            for (const { id, original_css, optimized_css } of results) {
+            for (const {
+              id,
+              original_css,
+              optimized_css,
+              removed,
+            } of results) {
               compilation.updateAsset(id, new RawSource(optimized_css));
 
-              if (!isSilent(this.options)) {
+              if (!isSilent(this.options) && removed > 0) {
                 printDiff({ original_css, optimized_css, id });
               }
             }

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -139,6 +139,7 @@ function createPostcssPlugins(
   preserveAllIBMFonts: boolean,
   preserveFlatpickr: boolean,
   strict: boolean,
+  report: { removed: number },
 ): AcceptedPlugin[] {
   return [
     {
@@ -163,12 +164,16 @@ function createPostcssPlugins(
 
             if (!shouldKeepRule(selectors, allowlist)) {
               node.remove();
+              report.removed++;
             }
           }
           return;
         }
 
-        optimizeStrictRule(node, { allowlist, preserveFlatpickr });
+        report.removed += optimizeStrictRule(node, {
+          allowlist,
+          preserveFlatpickr,
+        });
       },
       /**
        * AtRule visitor that removes unused IBM Plex @font-face declarations.
@@ -181,7 +186,7 @@ function createPostcssPlugins(
        */
       AtRule(node) {
         if (strict) {
-          optimizeStrictAtRule(node, { preserveFlatpickr });
+          report.removed += optimizeStrictAtRule(node, { preserveFlatpickr });
           if (!node.parent) return;
         }
 
@@ -218,6 +223,7 @@ function createPostcssPlugins(
 
           if (!(is_sans || is_mono)) {
             node.remove();
+            report.removed++;
           }
         }
       },
@@ -226,38 +232,67 @@ function createPostcssPlugins(
   ];
 }
 
-export function createOptimizedCss(options: CreateOptimizedCssOptions): string {
+/**
+ * The optimized CSS plus a count of how many Carbon rules/selectors/font-faces
+ * were removed. Callers use `removed` to suppress the size diff log when nothing
+ * was actually pruned (a size change alone can be misleading — e.g. PostCSS
+ * re-serialization on a stylesheet with no Carbon styles to remove).
+ */
+export type OptimizedCssReport = {
+  css: string;
+  removed: number;
+};
+
+export function optimizeCssWithReport(
+  options: CreateOptimizedCssOptions,
+): OptimizedCssReport {
   const { source, ids } = options;
   const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
   const strict = isStrict(options);
   const { allowlist, preserveFlatpickr } = buildUsage(ids);
+  const report = { removed: 0 };
 
-  return postcss(
+  const { css } = postcss(
     createPostcssPlugins(
       allowlist,
       preserveAllIBMFonts,
       preserveFlatpickr,
       strict,
+      report,
     ),
-  ).process(source, { from: options.from }).css;
+  ).process(source, { from: options.from });
+
+  return { css, removed: report.removed };
+}
+
+export async function optimizeCssWithReportAsync(
+  options: CreateOptimizedCssOptions,
+): Promise<OptimizedCssReport> {
+  const { source, ids } = options;
+  const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
+  const strict = isStrict(options);
+  const { allowlist, preserveFlatpickr } = buildUsage(ids);
+  const report = { removed: 0 };
+
+  const { css } = await postcss(
+    createPostcssPlugins(
+      allowlist,
+      preserveAllIBMFonts,
+      preserveFlatpickr,
+      strict,
+      report,
+    ),
+  ).process(source, { from: options.from });
+
+  return { css, removed: report.removed };
+}
+
+export function createOptimizedCss(options: CreateOptimizedCssOptions): string {
+  return optimizeCssWithReport(options).css;
 }
 
 export async function createOptimizedCssAsync(
   options: CreateOptimizedCssOptions,
 ): Promise<string> {
-  const { source, ids } = options;
-  const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
-  const strict = isStrict(options);
-  const { allowlist, preserveFlatpickr } = buildUsage(ids);
-
-  const result = await postcss(
-    createPostcssPlugins(
-      allowlist,
-      preserveAllIBMFonts,
-      preserveFlatpickr,
-      strict,
-    ),
-  ).process(source, { from: options.from });
-
-  return result.css;
+  return (await optimizeCssWithReportAsync(options)).css;
 }

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -1,7 +1,7 @@
 import type { Plugin } from "vite";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
-import { createOptimizedCss, isSilent } from "./create-optimized-css";
+import { isSilent, optimizeCssWithReport } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 
 /**
@@ -52,7 +52,7 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
 
         if (file.type === "asset" && isCssFile(id)) {
           const original_css = file.source;
-          const optimized_css = createOptimizedCss({
+          const { css: optimized_css, removed } = optimizeCssWithReport({
             ...options,
             source: original_css,
             ids,
@@ -61,7 +61,7 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
 
           file.source = optimized_css;
 
-          if (!silent) {
+          if (!silent && removed > 0) {
             printDiff({ original_css, optimized_css, id });
           }
         }

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -243,10 +243,15 @@ function shouldKeepSelector(selector: string, allowlist: Set<string>): boolean {
   );
 }
 
+/**
+ * Returns the number of Carbon selectors removed: the full selector count when
+ * the whole rule is dropped, the pruned count when a comma list is trimmed, or
+ * `0` when nothing changed.
+ */
 export function optimizeStrictRule(
   node: Rule,
   options: StrictCssOptimizerOptions,
-): void {
+): number {
   const { allowlist, preserveFlatpickr } = options;
   const selector = node.selector;
 
@@ -257,7 +262,7 @@ export function optimizeStrictRule(
       FLATPICKR_SELECTOR.test(selector)
     )
   ) {
-    return;
+    return 0;
   }
 
   const selectors = splitSelectorList(selector);
@@ -274,20 +279,32 @@ export function optimizeStrictRule(
 
   if (keptSelectors.length === 0) {
     node.remove();
-  } else if (keptSelectors.length < selectors.length) {
-    node.selector = keptSelectors.join(", ");
+    return selectors.length;
   }
+
+  if (keptSelectors.length < selectors.length) {
+    node.selector = keptSelectors.join(", ");
+    return selectors.length - keptSelectors.length;
+  }
+
+  return 0;
 }
 
+/**
+ * Returns `1` when the flatpickr keyframes node is removed, otherwise `0`.
+ */
 export function optimizeStrictAtRule(
   node: AtRule,
   options: Pick<StrictCssOptimizerOptions, "preserveFlatpickr">,
-): void {
+): number {
   if (
     !options.preserveFlatpickr &&
     node.name === "keyframes" &&
     FLATPICKR_KEYFRAMES.has(node.params)
   ) {
     node.remove();
+    return 1;
   }
+
+  return 0;
 }

--- a/tests/OptimizeCssPlugin.test.ts
+++ b/tests/OptimizeCssPlugin.test.ts
@@ -173,6 +173,29 @@ describe("OptimizeCssPlugin", () => {
     consoleSpy.mockRestore();
   });
 
+  test("skips diff logging when nothing is removed", async () => {
+    const consoleSpy = jest.spyOn(console, "log").mockImplementation();
+    const plugin = new OptimizeCssPlugin({ silent: false });
+    const carbonComponent = `node_modules/${CarbonSvelte.Components}/Button.svelte`;
+    // Button is imported and .bx--btn is the only Carbon class, so nothing is
+    // pruned even though Carbon imports exist (e.g. a secondary stylesheet).
+    const cssWithOnlyUsedCarbon = `* { box-sizing: border-box }
+.bx--btn { color: blue }`;
+
+    const mockCompiler = createMockCompiler({
+      assets: {
+        "styles.css": { source: () => cssWithOnlyUsedCarbon },
+      },
+      fileDependencies: [carbonComponent],
+    });
+
+    plugin.apply(asCompiler(mockCompiler));
+    await mockCompiler.waitForProcessAssets();
+
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
   test("passes experimental strict option to CSS optimization", async () => {
     const plugin = new OptimizeCssPlugin({
       silent: true,

--- a/tests/create-optimized-css.test.ts
+++ b/tests/create-optimized-css.test.ts
@@ -1,4 +1,7 @@
-import { createOptimizedCss } from "carbon-preprocess-svelte/plugins/create-optimized-css";
+import {
+  createOptimizedCss,
+  optimizeCssWithReport,
+} from "carbon-preprocess-svelte/plugins/create-optimized-css";
 
 describe("create-optimized-css", () => {
   const strict = { experimental: { strict: true } } as const;
@@ -367,5 +370,49 @@ button, .flatpickr-day.selected { color: red }`,
       ids: ["Button"],
     });
     expect(result).toEqual(".custom-class { color: red }");
+  });
+
+  describe("optimizeCssWithReport", () => {
+    test("counts pruned Carbon rules", () => {
+      const { css, removed } = optimizeCssWithReport({
+        source: `.bx--btn { color: blue }
+.bx--accordion { background: yellow }`,
+        ids: ["Button"],
+      });
+      expect(removed).toBe(1);
+      expect(css).toEqual(".bx--btn { color: blue }");
+    });
+
+    test("reports zero when nothing is pruned", () => {
+      const source = ".bx--btn { color: blue }\n.custom { color: red }";
+      const { css, removed } = optimizeCssWithReport({
+        source,
+        ids: ["Button"],
+      });
+      expect(removed).toBe(0);
+      expect(css).toEqual(source);
+    });
+
+    test("counts removed @font-face rules", () => {
+      const { removed } = optimizeCssWithReport({
+        source: `@font-face {
+  font-family: IBM Plex Sans;
+  font-style: normal;
+  font-weight: 700;
+}`,
+        ids: ["/Accordion.svelte"],
+      });
+      expect(removed).toBe(1);
+    });
+
+    test("counts selectors pruned from a comma list in strict mode", () => {
+      const { css, removed } = optimizeCssWithReport({
+        ...strict,
+        source: ".bx--btn, .bx--accordion { color: white }",
+        ids: ["Button"],
+      });
+      expect(removed).toBe(1);
+      expect(css).toEqual(".bx--btn { color: white }");
+    });
   });
 });


### PR DESCRIPTION
I've seen this when using bundling that emits multiple stylesheet chunks, where Carbon selectors are not pruned. It should not print a diff (especially if 0).

This fixes the logic to gate the per-stylesheet size diff on an actual removal count (Carbon rules/selectors and `@font-face`), not byte-size delta. Multi-stylesheet bundles re-serialized or font-pruned with no class removals no longer print a misleading diff.