### PR TITLE
fix(optimize-imports): leave un-indexed utilities as barrel imports

### DIFF
--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -7,6 +7,7 @@ import { components } from "../component-index";
 import { CarbonSvelte } from "../constants";
 
 const NODE_MODULES_REGEX = /node_modules/;
+const COMPONENT_NAME_REGEX = /^[A-Z]/;
 const SCRIPT_OPEN_TAG_REGEX = /^<script lang="ts">/;
 const SCRIPT_CLOSE_TAG_REGEX = /<\/script>$/;
 
@@ -15,24 +16,41 @@ function rewriteImport(
   node: ImportDeclaration,
   map: (specifier: ImportDeclaration["specifiers"][0]) => string,
 ) {
-  let content = "";
+  const rewritten: string[] = [];
+  const preserved: ImportDeclaration["specifiers"] = [];
 
   for (const specifier of node.specifiers) {
     const fragment = map(specifier);
     if (fragment) {
-      content += fragment + (!fragment.endsWith("\n") ? "\n" : "");
+      rewritten.push(fragment.trimEnd());
+    } else {
+      // Falsy return: keep specifier for barrel re-import below.
+      preserved.push(specifier);
     }
   }
 
-  if (content) s.update(node.start, node.end, content.trimEnd());
+  if (rewritten.length === 0) return;
+
+  // Mixed imports: put preserved names back on the barrel next to rewritten paths.
+  if (preserved.length > 0) {
+    const names = preserved.map((specifier) =>
+      specifier.imported.name === specifier.local.name
+        ? specifier.local.name
+        : `${specifier.imported.name} as ${specifier.local.name}`,
+    );
+    rewritten.push(
+      `import { ${names.join(", ")} } from "${node.source.value}";`,
+    );
+  }
+
+  s.update(node.start, node.end, rewritten.join("\n"));
 }
 
 /**
  * Svelte preprocessor that transforms barrel imports from Carbon libraries
  * into direct path imports for better tree-shaking and faster builds.
  *
- * This avoids loading the entire component index during development,
- * which can significantly improve HMR performance and build times.
+ * Skips loading the full component index, which speeds up HMR and builds.
  * @example
  * ```ts
  *   import { Button, Modal } from "carbon-components-svelte";
@@ -46,6 +64,10 @@ function rewriteImport(
  *   import Add from "carbon-icons-svelte/lib/Add.svelte";
  *   import Airplane from "carbon-pictograms-svelte/lib/Airplane.svelte";
  * ```
+ *
+ * Names missing from the component index: PascalCase gets an optimistic
+ * `src/Name/Name.svelte` path; camelCase stays on the barrel so utilities
+ * don't point at a `.svelte` file that isn't there.
  */
 export const optimizeImports: SveltePreprocessor<"script"> = () => {
   return {
@@ -71,14 +93,22 @@ export const optimizeImports: SveltePreprocessor<"script"> = () => {
             switch (import_name) {
               case CarbonSvelte.Components:
                 rewriteImport(s, node, ({ imported, local }) => {
-                  // Use index if available for backwards compatibility with special paths, like .js files.
-                  // Otherwise, use optimistic path for new components.
+                  // Prefer indexed path (handles .js and other special cases).
                   const import_path = components[imported.name]?.path;
-                  if (!import_path) {
+                  if (import_path) {
+                    return `import ${local.name} from "${import_path}";`;
+                  }
+
+                  // Not in index: PascalCase gets an optimistic component path;
+                  // camelCase stays on the barrel (utility, not a .svelte file).
+                  const looks_like_component = COMPONENT_NAME_REGEX.test(
+                    imported.name,
+                  );
+                  if (looks_like_component) {
                     return `import ${local.name} from "${import_name}/src/${imported.name}/${imported.name}.svelte";`;
                   }
 
-                  return `import ${local.name} from "${import_path}";`;
+                  return "";
                 });
                 break;
 

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -73,6 +73,23 @@ import filterTreeNodes from "carbon-components-svelte/src/utils/filterTreeNodes.
     );
   });
 
+  test("un-indexed camelCase utility is left untouched", () => {
+    expect(
+      preprocess({
+        content: `import { someFutureUtil } from "carbon-components-svelte"`,
+      }),
+    ).toEqual(`import { someFutureUtil } from "carbon-components-svelte"`);
+  });
+
+  test("mixed component and un-indexed utility import", () => {
+    expect(
+      preprocess({
+        content: `import { Button, someFutureUtil } from "carbon-components-svelte";`,
+      }),
+    ).toEqual(`import Button from "carbon-components-svelte/src/Button/Button.svelte";
+import { someFutureUtil } from "carbon-components-svelte";`);
+  });
+
   test("mixed imports should be handled correctly", () => {
     expect(
       preprocess({


### PR DESCRIPTION
Follow-up to [#132](https://github.com/carbon-design-system/carbon-preprocess-svelte/issues/132)

Fail gracefully for utilities (camelCase) that aren't indexed to avoid dev errors, because they don't follow the same, predictable path that components do.