### PR TITLE
feat(optimize-imports): add `optimistic` option to opt out of guessed paths

### DIFF
--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -11,6 +11,19 @@ const COMPONENT_NAME_REGEX = /^[A-Z]/;
 const SCRIPT_OPEN_TAG_REGEX = /^<script lang="ts">/;
 const SCRIPT_CLOSE_TAG_REGEX = /<\/script>$/;
 
+export type OptimizeImportsOptions = {
+  /**
+   * If a PascalCase import isn't in the bundled index, guess
+   * `carbon-components-svelte/src/Name/Name.svelte`. Works for components added
+   * after the index was built. Breaks the build if the name isn't real.
+   *
+   * `false` leaves un-indexed names on the barrel import. camelCase utilities
+   * always stay on the barrel either way.
+   * @default true
+   */
+  optimistic?: boolean;
+};
+
 function rewriteImport(
   s: MagicString,
   node: ImportDeclaration,
@@ -65,11 +78,15 @@ function rewriteImport(
  *   import Airplane from "carbon-pictograms-svelte/lib/Airplane.svelte";
  * ```
  *
- * Names missing from the component index: PascalCase gets an optimistic
- * `src/Name/Name.svelte` path; camelCase stays on the barrel so utilities
- * don't point at a `.svelte` file that isn't there.
+ * Un-indexed PascalCase names get a guessed path by default. Pass
+ * `{ optimistic: false }` to skip that. See {@link OptimizeImportsOptions.optimistic}.
  */
-export const optimizeImports: SveltePreprocessor<"script"> = () => {
+export const optimizeImports: SveltePreprocessor<
+  "script",
+  OptimizeImportsOptions
+> = (options) => {
+  const optimistic = options?.optimistic ?? true;
+
   return {
     name: "carbon:optimize-imports",
     script({ filename, content: raw }) {
@@ -99,12 +116,13 @@ export const optimizeImports: SveltePreprocessor<"script"> = () => {
                     return `import ${local.name} from "${import_path}";`;
                   }
 
-                  // Not in index: PascalCase gets an optimistic component path;
-                  // camelCase stays on the barrel (utility, not a .svelte file).
-                  const looks_like_component = COMPONENT_NAME_REGEX.test(
-                    imported.name,
-                  );
-                  if (looks_like_component) {
+                  // Not in index. When optimistic (the default), guess a src/
+                  // path for PascalCase names so newer carbon-components-svelte
+                  // releases work without re-indexing/upgrading this preprocessor
+                  // (see #97); a genuinely non-existent name surfaces as a
+                  // downstream resolution error. camelCase names are utilities,
+                  // not .svelte files, so they always stay on the barrel.
+                  if (optimistic && COMPONENT_NAME_REGEX.test(imported.name)) {
                     return `import ${local.name} from "${import_name}/src/${imported.name}/${imported.name}.svelte";`;
                   }
 

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -1,9 +1,13 @@
 import { optimizeImports } from "carbon-preprocess-svelte";
+import type { OptimizeImportsOptions } from "carbon-preprocess-svelte/preprocessors/optimize-imports";
 import type { Preprocessor, Processed } from "svelte/compiler";
 
-const preprocess = (options?: Partial<Parameters<Preprocessor>[0]>) => {
+const preprocess = (
+  options?: Partial<Parameters<Preprocessor>[0]>,
+  preprocessorOptions?: OptimizeImportsOptions,
+) => {
   return (
-    optimizeImports().script({
+    optimizeImports(preprocessorOptions).script({
       attributes: {},
       filename: "test.svelte",
       content: "",
@@ -71,6 +75,27 @@ import filterTreeNodes from "carbon-components-svelte/src/utils/filterTreeNodes.
     ).toEqual(
       'import NonExistent from "carbon-components-svelte/src/NonExistent/NonExistent.svelte";',
     );
+  });
+
+  test("optimistic: false leaves un-indexed component on the barrel", () => {
+    expect(
+      preprocess(
+        { content: "import { NonExistent } from 'carbon-components-svelte'" },
+        { optimistic: false },
+      ),
+    ).toEqual("import { NonExistent } from 'carbon-components-svelte'");
+  });
+
+  test("optimistic: false still rewrites indexed components", () => {
+    expect(
+      preprocess(
+        {
+          content: `import { Button, NonExistent } from "carbon-components-svelte";`,
+        },
+        { optimistic: false },
+      ),
+    ).toEqual(`import Button from "carbon-components-svelte/src/Button/Button.svelte";
+import { NonExistent } from "carbon-components-svelte";`);
   });
 
   test("un-indexed camelCase utility is left untouched", () => {


### PR DESCRIPTION
Adds an `optimistic` option to `optimizeImports` (default `true`, so behavior is unchanged).

Un-indexed PascalCase names are optimistically rewritten to a guessed `src/Name/Name.svelte` path, which lets newer `carbon-components-svelte` releases work without re-indexing (#98). The downside: when the name isn't a real component, the guessed path surfaces as a confusing downstream error rather than a clean resolution failure.

Set `optimistic: false` to leave un-indexed names on the barrel import instead, resolving via the package's real exports:

```ts
optimizeImports({ optimistic: false })
```

Indexed components and un-indexed camelCase utilities are unaffected.

Context: #98 introduced the optimistic behavior.