### PR TITLE
fix(optimize-imports): preserve type-only barrel imports

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -35,9 +35,11 @@ declare module "estree-walker" {
   type ImportDeclaration = CustomElement<{
     type: "ImportDeclaration";
     source: { value: string };
+    importKind?: "type" | "value";
     specifiers: Array<{
       local: { name: string };
       imported: { name: string };
+      importKind?: "type" | "value";
     }>;
   }>;
 

--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -16,11 +16,16 @@ function rewriteImport(
   node: ImportDeclaration,
   map: (specifier: ImportDeclaration["specifiers"][0]) => string,
 ) {
+  // Type-only statements (`import type { ... }`) never reference a real
+  // `.svelte` file, so leave them entirely untouched.
+  if (node.importKind === "type") return;
+
   const rewritten: string[] = [];
   const preserved: ImportDeclaration["specifiers"] = [];
 
   for (const specifier of node.specifiers) {
-    const fragment = map(specifier);
+    // Per-specifier type imports (`import { type X, Y }`) stay on the barrel.
+    const fragment = specifier.importKind === "type" ? "" : map(specifier);
     if (fragment) {
       rewritten.push(fragment.trimEnd());
     } else {
@@ -33,11 +38,12 @@ function rewriteImport(
 
   // Mixed imports: put preserved names back on the barrel next to rewritten paths.
   if (preserved.length > 0) {
-    const names = preserved.map((specifier) =>
-      specifier.imported.name === specifier.local.name
-        ? specifier.local.name
-        : `${specifier.imported.name} as ${specifier.local.name}`,
-    );
+    const names = preserved.map((specifier) => {
+      const prefix = specifier.importKind === "type" ? "type " : "";
+      return specifier.imported.name === specifier.local.name
+        ? `${prefix}${specifier.local.name}`
+        : `${prefix}${specifier.imported.name} as ${specifier.local.name}`;
+    });
     rewritten.push(
       `import { ${names.join(", ")} } from "${node.source.value}";`,
     );

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -182,6 +182,23 @@ import Analytics from "carbon-pictograms-svelte/lib/Analytics.svelte";`);
         `);
   });
 
+  test("type-only barrel statements are left untouched", () => {
+    expect(
+      preprocess({
+        content: `import type { ButtonProps } from "carbon-components-svelte";`,
+      }),
+    ).toEqual(`import type { ButtonProps } from "carbon-components-svelte";`);
+  });
+
+  test("type-only specifiers stay on the barrel while values are rewritten", () => {
+    expect(
+      preprocess({
+        content: `import { Button, type ButtonSize } from "carbon-components-svelte";`,
+      }),
+    ).toEqual(`import Button from "carbon-components-svelte/src/Button/Button.svelte";
+import { type ButtonSize } from "carbon-components-svelte";`);
+  });
+
   test("backward compatibility with various export patterns", () => {
     expect(
       preprocess({


### PR DESCRIPTION
Type-only specifiers hit the PascalCase fallback and became value
imports of nonexistent `.svelte` files. Now whole `import type`
statements pass through and `type` specifiers stay on the barrel.

```ts
// input
import type { ButtonProps } from "carbon-components-svelte";
import { Button, type ButtonSize } from "carbon-components-svelte";

// before (broken): drops `type`, points at a file that doesn't exist
import ButtonProps from "carbon-components-svelte/src/ButtonProps/ButtonProps.svelte";
import Button from "carbon-components-svelte/src/Button/Button.svelte";

// after
import type { ButtonProps } from "carbon-components-svelte";
import Button from "carbon-components-svelte/src/Button/Button.svelte";
import { type ButtonSize } from "carbon-components-svelte";
```

### Changes
- `rewriteImport`: early-return on `node.importKind === "type"`; skip rewriting per-specifier `type` imports and retain the `type` modifier when re-emitting the barrel for mixed statements.
- `global.d.ts`: declare the optional `importKind` field the parser already exposes.
- Tests: cover a type-only barrel statement (untouched) and mixed value + `type` specifiers.

### Verification
- `bun run typecheck` — clean
- `bun test` — 192 pass, 0 fail
- `bun lint:fix` — clean