### PR TITLE
perf(optimize-imports): skip parse for files without carbon- imports

### DIFF
--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -77,6 +77,10 @@ export const optimizeImports: SveltePreprocessor<"script"> = () => {
       if (!filename) return;
       if (NODE_MODULES_REGEX.test(filename)) return;
 
+      // Fast path: the only rewritable import sources contain "carbon-".
+      // Skip MagicString + svelte parse for the common no-Carbon file.
+      if (!raw.includes("carbon-")) return;
+
       /**
        * The Svelte compiler's parse() function expects a full Svelte component,
        * not just a script fragment. Wrap the raw script content in script tags

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -22,6 +22,15 @@ describe("optimizeImports", () => {
     ).toBeUndefined();
   });
 
+  test("files without a carbon- substring are returned untouched", () => {
+    expect(
+      preprocess({
+        content: `import { something } from "other-module";
+import defaultThing from "another-module";`,
+      }),
+    ).toBeUndefined();
+  });
+
   test("barrel imports", () => {
     expect(
       preprocess({


### PR DESCRIPTION
The `script` hook runs on every `.svelte` file on each build and HMR
update, yet most files import no Carbon packages. A substring guard
short-circuits them before any MagicString + svelte parse + walk.

```ts
if (!filename) return;
if (NODE_MODULES_REGEX.test(filename)) return;

// Fast path: the only rewritable import sources contain "carbon-".
// Skip MagicString + svelte parse for the common no-Carbon file.
if (!raw.includes("carbon-")) return;
```

The three rewritable sources (`carbon-components-svelte`,
`carbon-icons-svelte`, `carbon-pictograms-svelte`) all share the
`carbon-` prefix, so a file lacking that substring can never be
rewritten. Returning `undefined` leaves it untouched — the same
no-change signal already used elsewhere in the hook.

A test asserts a non-Carbon file returns `undefined`; existing
rewrite cases still pass.