### PR TITLE
feat(optimize-css): add safelist and content escape hatches

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,31 @@ optimizeCss({
   preserveAllIBMFonts: true,
 
   /**
+   * Class selectors to always keep, regardless of which components are
+   * imported. Use for Carbon classes the allowlist misses: hand-written
+   * classes in app markup (e.g. `<div class="bx--grid">`) and theme/layout
+   * utilities that no component file references.
+   *
+   * Each entry is either:
+   * - a `string`, matched literally as a complete class token. `.bx--grid`
+   *   keeps `.bx--grid` and `.bx--grid:hover`, but not `.bx--grid--wide`
+   * - a `RegExp`, tested against the whole selector. `/^\.bx--btn--/` keeps
+   *   every `.bx--btn--*` variant
+   *
+   * @default []
+   */
+  safelist: [".bx--grid", ".bx--aspect-ratio", /^\.bx--btn--/],
+
+  /**
+   * Glob patterns (relative to the working directory) of source files to scan
+   * for literal `bx--`-prefixed tokens. Every token found is kept. Use when
+   * class names are built at runtime. See the warning below.
+   *
+   * @default undefined
+   */
+  content: ["src/**/*.{svelte,js,ts}"],
+
+  /**
    * Experimental. Enables stricter CSS tree-shaking that can drastically
    * reduce output size compared to the default baseline, depending on which
    * Carbon components you import. Small bundles that only use a handful of
@@ -301,6 +326,21 @@ optimizeCss({
   },
 });
 ```
+
+> [!WARNING]
+> **Dynamically constructed class names are not detected.** The allowlist comes from Carbon component source files you import. It only knows about classes those components reference. Runtime assembly is invisible:
+>
+> ```svelte
+> <!-- pruned: optimizer never sees literal `bx--btn--secondary` -->
+> <button class={`bx--btn--${kind}`}>...</button>
+> ```
+>
+> Hand-written Carbon classes in your markup (e.g. `<div class="bx--grid">`) have the same problem. No imported component references them, so they get pruned. If the plugin "deleted your styles," this is usually why.
+>
+> Two ways to fix it:
+>
+> - **`safelist`**: list selectors (or a `RegExp`) to keep: `safelist: [".bx--grid", /^\.bx--btn--/]`.
+> - **`content`**: scan your source for literal `bx--` prefixes: `content: ["src/**/*.{svelte,js,ts}"]`.
 
 ### `OptimizeCssPlugin`
 

--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -3,6 +3,7 @@ import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
 import { isSilent, optimizeCssWithReportAsync } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
+import { scanContentClasses } from "./scan-content";
 
 /**
  * Webpack plugin that removes unused Carbon CSS classes from production builds.
@@ -76,6 +77,7 @@ class OptimizeCssPlugin {
             if (ids.size === 0) return;
 
             const cssAssetIds = Object.keys(assets).filter(isCssFile);
+            const contentClasses = scanContentClasses(this.options.content);
 
             const results = await Promise.all(
               cssAssetIds.map(async (id) => {
@@ -88,6 +90,7 @@ class OptimizeCssPlugin {
                       : original_css,
                     ids,
                     from: id,
+                    contentClasses,
                   });
                 return { id, original_css, optimized_css, removed };
               }),

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -4,6 +4,7 @@ import postcss from "postcss";
 import discardEmpty from "postcss-discard-empty";
 import { components } from "../component-index";
 import { ALWAYS_ON_CLASSES, CARBON_PREFIX } from "../constants";
+import { isSafelisted, type SafelistEntry } from "./safelist";
 import {
   optimizeStrictAtRule,
   optimizeStrictRule,
@@ -38,6 +39,38 @@ export type OptimizeCssOptions = {
    * @default false
    */
   preserveAllIBMFonts?: boolean;
+
+  /**
+   * Class selectors to always keep, regardless of which components are
+   * imported. For Carbon classes the allowlist misses:
+   * - Hand-written Carbon classes in app markup (e.g. `<div class="bx--grid">`)
+   * - Theme/layout utilities that no component file references
+   *
+   * Each entry is either:
+   * - a `string`, matched literally as a complete class token. `.bx--grid`
+   *   keeps `.bx--grid` and `.bx--grid:hover` but not `.bx--grid--wide`
+   * - a `RegExp`, tested against the whole selector. `/^\.bx--btn--/` keeps
+   *   every `.bx--btn--*` variant
+   *
+   * Matching selectors are kept in both default and `experimental.strict`
+   * modes. For ``class={`bx--btn--${x}`}``, a literal string entry is not
+   * enough. Use a `RegExp` entry or the `content` option.
+   *
+   * @example
+   * safelist: [".bx--grid", ".bx--aspect-ratio", /^\.bx--btn--/]
+   */
+  safelist?: Array<SafelistEntry>;
+
+  /**
+   * Glob patterns (relative to the current working directory) of source files
+   * to scan for literal `bx--`-prefixed tokens. Every token found is kept.
+   * For ``class={`bx--btn--${kind}`}``, the prefix `bx--btn--` in source
+   * keeps runtime variants like `.bx--btn--primary`.
+   *
+   * @example
+   * content: ["src/**\/*.{svelte,js,ts}"]
+   */
+  content?: string[];
 
   experimental?: {
     /**
@@ -82,6 +115,12 @@ type CreateOptimizedCssOptions = OptimizeCssOptions & {
   ids: Iterable<string>;
   /** PostCSS `from` option. Pass asset/chunk path when available, or omit for `undefined`. */
   from?: string | undefined;
+  /**
+   * Class selectors (`.bx--*`) from scanning `content` globs. Pre-scanned by
+   * the plugin so the per-asset optimizer does no filesystem I/O. Merged into
+   * the allowlist with imported component classes.
+   */
+  contentClasses?: Iterable<string>;
 };
 
 /**
@@ -92,7 +131,10 @@ type CreateOptimizedCssOptions = OptimizeCssOptions & {
  * `.bx--body` is always kept; apps set it on `<body>` but no component file
  * references it.
  */
-function buildUsage(ids: Iterable<string>): {
+function buildUsage(
+  ids: Iterable<string>,
+  contentClasses?: Iterable<string>,
+): {
   allowlist: Set<string>;
   preserveFlatpickr: boolean;
 } {
@@ -111,6 +153,10 @@ function buildUsage(ids: Iterable<string>): {
         allowlist.add(cls);
       }
     }
+  }
+
+  for (const cls of contentClasses ?? []) {
+    allowlist.add(cls);
   }
 
   return { allowlist, preserveFlatpickr };
@@ -139,6 +185,7 @@ function createPostcssPlugins(
   preserveAllIBMFonts: boolean,
   preserveFlatpickr: boolean,
   strict: boolean,
+  safelist: readonly SafelistEntry[],
   report: { removed: number },
 ): AcceptedPlugin[] {
   return [
@@ -156,6 +203,15 @@ function createPostcssPlugins(
           const selector = node.selector;
 
           if (CARBON_PREFIX.test(selector)) {
+            if (
+              safelist.length > 0 &&
+              selector
+                .split(",")
+                .some((selectee) => isSafelisted(selectee.trim(), safelist))
+            ) {
+              return;
+            }
+
             const selectors = selector.split(",").filter((selectee) => {
               const value = selectee.trim() ?? "";
               const [, rest] = value.split(".");
@@ -173,6 +229,7 @@ function createPostcssPlugins(
         report.removed += optimizeStrictRule(node, {
           allowlist,
           preserveFlatpickr,
+          safelist,
         });
       },
       /**
@@ -249,7 +306,11 @@ export function optimizeCssWithReport(
   const { source, ids } = options;
   const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
   const strict = isStrict(options);
-  const { allowlist, preserveFlatpickr } = buildUsage(ids);
+  const safelist = options.safelist ?? [];
+  const { allowlist, preserveFlatpickr } = buildUsage(
+    ids,
+    options.contentClasses,
+  );
   const report = { removed: 0 };
 
   const { css } = postcss(
@@ -258,6 +319,7 @@ export function optimizeCssWithReport(
       preserveAllIBMFonts,
       preserveFlatpickr,
       strict,
+      safelist,
       report,
     ),
   ).process(source, { from: options.from });
@@ -271,7 +333,11 @@ export async function optimizeCssWithReportAsync(
   const { source, ids } = options;
   const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
   const strict = isStrict(options);
-  const { allowlist, preserveFlatpickr } = buildUsage(ids);
+  const safelist = options.safelist ?? [];
+  const { allowlist, preserveFlatpickr } = buildUsage(
+    ids,
+    options.contentClasses,
+  );
   const report = { removed: 0 };
 
   const { css } = await postcss(
@@ -280,6 +346,7 @@ export async function optimizeCssWithReportAsync(
       preserveAllIBMFonts,
       preserveFlatpickr,
       strict,
+      safelist,
       report,
     ),
   ).process(source, { from: options.from });

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -3,6 +3,7 @@ import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
 import { isSilent, optimizeCssWithReport } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
+import { scanContentClasses } from "./scan-content";
 
 /**
  * Vite/Rollup plugin that removes unused Carbon CSS classes from production builds.
@@ -23,6 +24,8 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
    * Populated during the transform phase, consumed during generateBundle.
    */
   const ids = new Set<string>();
+  /** Classes from `content` globs. Cached after first scan. */
+  let contentClasses: string[] | undefined;
 
   return {
     name: "vite:carbon:optimize-css",
@@ -47,6 +50,10 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
       // Skip processing if no Carbon Svelte imports are found.
       if (ids.size === 0) return;
 
+      if (contentClasses === undefined) {
+        contentClasses = scanContentClasses(options?.content);
+      }
+
       for (const id in bundle) {
         const file = bundle[id];
 
@@ -57,6 +64,7 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
             source: original_css,
             ids,
             from: id,
+            contentClasses,
           });
 
           file.source = optimized_css;

--- a/src/plugins/safelist.ts
+++ b/src/plugins/safelist.ts
@@ -1,0 +1,46 @@
+/** A safelist entry: a class selector matched literally, or a RegExp. */
+export type SafelistEntry = string | RegExp;
+
+/** Characters that continue a class token, so `.bx--grid` ≠ `.bx--grid-narrow`. */
+const CLASS_TOKEN_CHAR = /[A-Za-z0-9_-]/;
+
+/**
+ * Whether `klass` appears as a complete class token in `selector`.
+ *
+ * `.bx--grid` matches `.bx--grid`, `.bx--grid:hover`, `div.bx--grid`, and
+ * `.bx--grid .bx--row`, but not `.bx--grid-narrow` or `.bx--grid--wide`
+ * (use a RegExp entry to keep BEM children).
+ */
+function hasClassToken(selector: string, klass: string): boolean {
+  let from = 0;
+
+  for (;;) {
+    const index = selector.indexOf(klass, from);
+    if (index === -1) return false;
+
+    const next = selector[index + klass.length];
+    if (next === undefined || !CLASS_TOKEN_CHAR.test(next)) return true;
+
+    from = index + 1;
+  }
+}
+
+/**
+ * Whether a single selector is safelisted and must be kept regardless of the
+ * importer-derived allowlist. String entries match a class token literally;
+ * RegExp entries are tested against the whole selector.
+ */
+export function isSafelisted(
+  selector: string,
+  safelist: readonly SafelistEntry[],
+): boolean {
+  for (const entry of safelist) {
+    if (typeof entry === "string") {
+      if (hasClassToken(selector, entry)) return true;
+    } else if (entry.test(selector)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/plugins/scan-content.ts
+++ b/src/plugins/scan-content.ts
@@ -1,0 +1,44 @@
+import { globSync, readFileSync } from "node:fs";
+
+/** Literal `bx--`-prefixed tokens as they appear in source markup. */
+const CARBON_TOKEN = /bx--[A-Za-z0-9_-]+/g;
+
+/**
+ * Scan files matched by `content` globs for literal `bx--`-prefixed tokens.
+ * Returns them as class selectors (`.bx--token`).
+ *
+ * For ``class={`bx--btn--${kind}`}``, the importer-based allowlist only sees
+ * the prefix in your source (`bx--btn--`). Prefix matching then keeps
+ * `.bx--btn--primary` and similar at runtime.
+ *
+ * Globs resolve relative to the current working directory. Returns an empty
+ * array when `content` is omitted or globbing fails.
+ */
+export function scanContentClasses(content?: readonly string[]): string[] {
+  if (!content || content.length === 0) return [];
+
+  let files: string[];
+  try {
+    files = globSync([...content]);
+  } catch {
+    return [];
+  }
+
+  const classes = new Set<string>();
+
+  for (const file of files) {
+    let source: string;
+    try {
+      source = readFileSync(file, "utf-8");
+    } catch {
+      // Skip directories and unreadable matches.
+      continue;
+    }
+
+    for (const token of source.match(CARBON_TOKEN) ?? []) {
+      classes.add(`.${token}`);
+    }
+  }
+
+  return [...classes];
+}

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -5,6 +5,7 @@ import {
   CARBON_PREFIX,
   CONTEXT_ANCESTORS,
 } from "../constants";
+import { isSafelisted, type SafelistEntry } from "./safelist";
 
 const CARBON_CLASS = /\.bx--[A-Za-z0-9_-]+/g;
 const SELECTOR_COMBINATOR = /[\s>+~]/;
@@ -43,6 +44,7 @@ const SHARED_CLASSES = getSharedClasses();
 export type StrictCssOptimizerOptions = {
   allowlist: Set<string>;
   preserveFlatpickr: boolean;
+  safelist: readonly SafelistEntry[];
 };
 
 function getSharedClasses(): Set<string> {
@@ -252,7 +254,7 @@ export function optimizeStrictRule(
   node: Rule,
   options: StrictCssOptimizerOptions,
 ): number {
-  const { allowlist, preserveFlatpickr } = options;
+  const { allowlist, preserveFlatpickr, safelist } = options;
   const selector = node.selector;
 
   if (
@@ -267,6 +269,10 @@ export function optimizeStrictRule(
 
   const selectors = splitSelectorList(selector);
   const keptSelectors = selectors.filter((selectee) => {
+    if (isSafelisted(selectee, safelist)) {
+      return true;
+    }
+
     if (FLATPICKR_SELECTOR.test(selectee) && !preserveFlatpickr) {
       return false;
     }

--- a/tests/create-optimized-css.test.ts
+++ b/tests/create-optimized-css.test.ts
@@ -3,6 +3,8 @@ import {
   optimizeCssWithReport,
 } from "carbon-preprocess-svelte/plugins/create-optimized-css";
 
+const BTN_VARIANT_RE = /^\.bx--btn--/;
+
 describe("create-optimized-css", () => {
   const strict = { experimental: { strict: true } } as const;
 
@@ -370,6 +372,107 @@ button, .flatpickr-day.selected { color: red }`,
       ids: ["Button"],
     });
     expect(result).toEqual(".custom-class { color: red }");
+  });
+
+  describe("safelist", () => {
+    const grid = ".bx--grid { display: grid }";
+
+    test("prunes a hand-written bx--grid rule when not safelisted", () => {
+      expect(createOptimizedCss({ source: grid, ids: ["Button"] })).toEqual("");
+      expect(
+        createOptimizedCss({ ...strict, source: grid, ids: ["Button"] }),
+      ).toEqual("");
+    });
+
+    test("keeps a safelisted bx--grid rule (string entry)", () => {
+      const safelist = [".bx--grid"];
+      expect(
+        createOptimizedCss({ source: grid, ids: ["Button"], safelist }),
+      ).toEqual(grid);
+      expect(
+        createOptimizedCss({
+          ...strict,
+          source: grid,
+          ids: ["Button"],
+          safelist,
+        }),
+      ).toEqual(grid);
+    });
+
+    test("string entry matches a class token, not a prefix", () => {
+      const source = ".bx--grid { display: grid }\n.bx--grid-narrow { gap: 0 }";
+      expect(
+        createOptimizedCss({
+          ...strict,
+          source,
+          ids: ["Button"],
+          safelist: [".bx--grid"],
+        }),
+      ).toEqual(".bx--grid { display: grid }");
+    });
+
+    test("RegExp entry keeps every matching selector", () => {
+      const source =
+        ".bx--btn--primary { color: white }\n.bx--btn--secondary { color: gray }";
+      expect(
+        createOptimizedCss({
+          ...strict,
+          source,
+          ids: ["Accordion"],
+          safelist: [BTN_VARIANT_RE],
+        }),
+      ).toEqual(source);
+    });
+
+    test("keeps the whole rule in default mode when any selector matches", () => {
+      const source = ".bx--grid, .bx--unused { display: grid }";
+      expect(
+        createOptimizedCss({
+          source,
+          ids: ["Button"],
+          safelist: [".bx--grid"],
+        }),
+      ).toEqual(source);
+    });
+
+    test("keeps only the matching selector in strict mode", () => {
+      const source = ".bx--grid, .bx--unused { display: grid }";
+      expect(
+        createOptimizedCss({
+          ...strict,
+          source,
+          ids: ["Button"],
+          safelist: [".bx--grid"],
+        }),
+      ).toEqual(".bx--grid { display: grid }");
+    });
+
+    test("keeps a safelisted flatpickr selector in strict mode", () => {
+      const source = ".flatpickr-calendar { visibility: hidden }";
+      expect(
+        createOptimizedCss({
+          ...strict,
+          source,
+          ids: ["Button"],
+          safelist: [".flatpickr-calendar"],
+        }),
+      ).toEqual(source);
+    });
+  });
+
+  describe("content (scanned classes)", () => {
+    test("keeps dynamic class variants from a scanned prefix", () => {
+      const source = ".bx--btn--ghost { color: blue }";
+      expect(createOptimizedCss({ source, ids: ["Accordion"] })).toEqual("");
+      expect(
+        createOptimizedCss({
+          ...strict,
+          source,
+          ids: ["Accordion"],
+          contentClasses: [".bx--btn--"],
+        }),
+      ).toEqual(source);
+    });
   });
 
   describe("optimizeCssWithReport", () => {

--- a/tests/scan-content.test.ts
+++ b/tests/scan-content.test.ts
@@ -1,0 +1,36 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { scanContentClasses } from "carbon-preprocess-svelte/plugins/scan-content";
+
+describe("scanContentClasses", () => {
+  test("returns an empty array when no content is provided", () => {
+    expect(scanContentClasses()).toEqual([]);
+    expect(scanContentClasses([])).toEqual([]);
+  });
+
+  test("extracts literal bx-- tokens from matched files", () => {
+    const dir = mkdtempSync(join(tmpdir(), "scan-content-"));
+    try {
+      writeFileSync(
+        join(dir, "App.svelte"),
+        `<div class="bx--grid">\n  <button class={\`bx--btn--\${kind}\`} />\n</div>`,
+      );
+      writeFileSync(join(dir, "ignore.txt"), "no carbon here");
+
+      const classes = scanContentClasses([join(dir, "*.svelte")]).sort();
+      expect(classes).toEqual([".bx--btn--", ".bx--grid"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns an empty array when globs match nothing", () => {
+    const dir = mkdtempSync(join(tmpdir(), "scan-content-"));
+    try {
+      expect(scanContentClasses([join(dir, "*.svelte")])).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Why

`optimizeCss` builds its kept-class allowlist only from the Carbon component sources you import. Two legitimate patterns are invisible to it and get pruned:

- Hand-written Carbon classes in app markup: `<div class="bx--grid">`
- Dynamically constructed class names: ``class={`bx--btn--${kind}`}``

This is the most common "the plugin deleted my styles" failure, and until now the only workaround was to stop using the plugin.

## What

Two opt-in options on `OptimizeCssOptions`, both honored in default and `experimental.strict` modes.

### `safelist`

Selectors to always keep. Strings match a class token literally; RegExp entries are tested against the whole selector.

```js
// vite.config.js
optimizeCss({
  safelist: [".bx--grid", ".bx--aspect-ratio", /^\.bx--btn--/],
});
```

`.bx--grid` keeps `.bx--grid` and `.bx--grid:hover`, but not `.bx--grid--wide` (use a RegExp for variants).

### `content`

Globs of source files to scan for literal `bx--` tokens, which are then kept. This is the fix for dynamic class names: the literal prefix `bx--btn--` is scanned out of source so its runtime variants survive.

```js
optimizeCss({
  content: ["src/**/*.{svelte,js,ts}"],
});
```

## Notes

- Zero new dependencies. `content` scanning uses `node:fs` `globSync`.
- README documents both options plus a warning that calls out the dynamic-class footgun.

## Tests

- Proves a hand-written `.bx--grid` rule survives when safelisted and is pruned when not, in both modes.
- Covers token-vs-prefix matching, RegExp entries, comma-list behavior (whole rule in default, per-selector in strict), flatpickr override, and the content scanner.
- `bun lint`, `bun test` (201 pass), and `bun run typecheck` all clean.