### PR TITLE
feat(optimize-css): add debug option for per-asset summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,15 @@ optimizeCss({
   silent: true,
 
   /**
+   * Set to `true` to print a per-asset summary after optimization: which Carbon
+   * components were found, allowlist size, strict/flatpickr flags, how many
+   * rules were removed, and up to 20 pruned selectors. Use when styles vanish
+   * and you need to see why. Still prints when `silent` is `true`.
+   * @default false
+   */
+  debug: false,
+
+  /**
    * By default, pre-compiled Carbon StyleSheets ship `@font-face` rules
    * for all available IBM Plex fonts, many of which are not actually
    * used in Carbon Svelte components.
@@ -341,6 +350,16 @@ optimizeCss({
 >
 > - **`safelist`**: list selectors (or a `RegExp`) to keep: `safelist: [".bx--grid", /^\.bx--btn--/]`.
 > - **`content`**: scan your source for literal `bx--` prefixes: `content: ["src/**/*.{svelte,js,ts}"]`.
+>
+> Set `debug: true` to print which components were detected and a sample of pruned selectors:
+>
+> ```
+> [carbon-preprocess-svelte] optimizeCss · assets/index-CU4gbKFa.css
+>   components detected: Button, DataTable, Modal (3)
+>   allowlist classes:   214 · strict: false · flatpickr: false
+>   rules removed:       1180
+>   sample pruned:       .bx--accordion, .bx--tabs--scrollable__nav-link, …
+> ```
 
 ### `OptimizeCssPlugin`
 

--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -2,7 +2,7 @@ import type { Compiler } from "webpack";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
 import { isSilent, optimizeCssWithReportAsync } from "./create-optimized-css";
-import { printDiff } from "./print-diff";
+import { logOptimizationResult } from "./print-diff";
 import { scanContentClasses } from "./scan-content";
 
 /**
@@ -82,17 +82,20 @@ class OptimizeCssPlugin {
             const results = await Promise.all(
               cssAssetIds.map(async (id) => {
                 const original_css = assets[id].source();
-                const { css: optimized_css, removed } =
-                  await optimizeCssWithReportAsync({
-                    ...this.options,
-                    source: Buffer.isBuffer(original_css)
-                      ? original_css.toString()
-                      : original_css,
-                    ids,
-                    from: id,
-                    contentClasses,
-                  });
-                return { id, original_css, optimized_css, removed };
+                const {
+                  css: optimized_css,
+                  removed,
+                  debug: debugInfo,
+                } = await optimizeCssWithReportAsync({
+                  ...this.options,
+                  source: Buffer.isBuffer(original_css)
+                    ? original_css.toString()
+                    : original_css,
+                  ids,
+                  from: id,
+                  contentClasses,
+                });
+                return { id, original_css, optimized_css, removed, debugInfo };
               }),
             );
 
@@ -101,12 +104,18 @@ class OptimizeCssPlugin {
               original_css,
               optimized_css,
               removed,
+              debugInfo,
             } of results) {
               compilation.updateAsset(id, new RawSource(optimized_css));
 
-              if (!isSilent(this.options) && removed > 0) {
-                printDiff({ original_css, optimized_css, id });
-              }
+              logOptimizationResult({
+                id,
+                original_css,
+                optimized_css,
+                removed,
+                debug: debugInfo,
+                silent: isSilent(this.options),
+              });
             }
           },
         );

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -26,6 +26,15 @@ export type OptimizeCssOptions = {
   verbose?: boolean;
 
   /**
+   * Print a per-asset summary after optimization: detected components,
+   * allowlist size, strict/flatpickr flags, removed rule count, and up to
+   * {@link DEBUG_PRUNED_SAMPLE_CAP} pruned selectors. Still prints when
+   * `silent` is `true`.
+   * @default false
+   */
+  debug?: boolean;
+
+  /**
    * By default, pre-compiled Carbon StyleSheets ship `@font-face` rules
    * for all available IBM Plex fonts, many of which are not actually
    * used in Carbon Svelte components.
@@ -110,6 +119,23 @@ function isStrict(options?: OptimizeCssOptions): boolean {
   return options?.experimental?.strict === true;
 }
 
+/** Max pruned selectors kept for the `debug` summary. */
+export const DEBUG_PRUNED_SAMPLE_CAP = 20;
+
+function createPruneCollector(sample: string[]) {
+  let truncated = false;
+  return {
+    collect: (selector: string) => {
+      if (sample.length < DEBUG_PRUNED_SAMPLE_CAP) {
+        sample.push(selector);
+        return;
+      }
+      truncated = true;
+    },
+    wasTruncated: () => truncated,
+  };
+}
+
 type CreateOptimizedCssOptions = OptimizeCssOptions & {
   source: Uint8Array | string;
   ids: Iterable<string>;
@@ -134,11 +160,14 @@ type CreateOptimizedCssOptions = OptimizeCssOptions & {
 function buildUsage(
   ids: Iterable<string>,
   contentClasses?: Iterable<string>,
+  debug = false,
 ): {
   allowlist: Set<string>;
   preserveFlatpickr: boolean;
+  detectedComponents: string[];
 } {
   const allowlist = new Set(ALWAYS_ON_CLASSES);
+  const detected = debug ? new Set<string>() : null;
   let preserveFlatpickr = false;
 
   for (const id of ids) {
@@ -149,6 +178,7 @@ function buildUsage(
     }
 
     if (name in components) {
+      detected?.add(name);
       for (const cls of components[name].classes) {
         allowlist.add(cls);
       }
@@ -159,7 +189,11 @@ function buildUsage(
     allowlist.add(cls);
   }
 
-  return { allowlist, preserveFlatpickr };
+  return {
+    allowlist,
+    preserveFlatpickr,
+    detectedComponents: detected ? [...detected].sort() : [],
+  };
 }
 
 function shouldKeepRule(selectors: string[], allowlist: Set<string>): boolean {
@@ -187,6 +221,7 @@ function createPostcssPlugins(
   strict: boolean,
   safelist: readonly SafelistEntry[],
   report: { removed: number },
+  collectPruned?: (selector: string) => void,
 ): AcceptedPlugin[] {
   return [
     {
@@ -219,6 +254,12 @@ function createPostcssPlugins(
             });
 
             if (!shouldKeepRule(selectors, allowlist)) {
+              if (collectPruned) {
+                for (const selectee of selector.split(",")) {
+                  const trimmed = selectee.trim();
+                  if (trimmed) collectPruned(trimmed);
+                }
+              }
               node.remove();
               report.removed++;
             }
@@ -230,6 +271,7 @@ function createPostcssPlugins(
           allowlist,
           preserveFlatpickr,
           safelist,
+          onRemove: collectPruned,
         });
       },
       /**
@@ -298,60 +340,86 @@ function createPostcssPlugins(
 export type OptimizedCssReport = {
   css: string;
   removed: number;
+  debug?: OptimizeCssDebugInfo;
 };
+
+export type OptimizeCssDebugInfo = {
+  components: string[];
+  allowlistSize: number;
+  preserveFlatpickr: boolean;
+  strict: boolean;
+  prunedSample: string[];
+  prunedSampleTruncated: boolean;
+};
+
+function prepareOptimization(options: CreateOptimizedCssOptions): {
+  plugins: AcceptedPlugin[];
+  finalize: (css: string) => OptimizedCssReport;
+} {
+  const { ids } = options;
+  const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
+  const strict = isStrict(options);
+  const debug = options?.debug === true;
+  const safelist = options.safelist ?? [];
+  const { allowlist, preserveFlatpickr, detectedComponents } = buildUsage(
+    ids,
+    options.contentClasses,
+    debug,
+  );
+  const report = { removed: 0 };
+  const prunedSample = debug ? ([] as string[]) : undefined;
+  const pruneCollector = prunedSample
+    ? createPruneCollector(prunedSample)
+    : undefined;
+  const collectPruned = pruneCollector?.collect;
+
+  const plugins = createPostcssPlugins(
+    allowlist,
+    preserveAllIBMFonts,
+    preserveFlatpickr,
+    strict,
+    safelist,
+    report,
+    collectPruned,
+  );
+
+  return {
+    plugins,
+    finalize: (css) => {
+      const result: OptimizedCssReport = { css, removed: report.removed };
+      if (debug && prunedSample && pruneCollector) {
+        result.debug = {
+          components: detectedComponents,
+          allowlistSize: allowlist.size,
+          preserveFlatpickr,
+          strict,
+          prunedSample,
+          prunedSampleTruncated: pruneCollector.wasTruncated(),
+        };
+      }
+      return result;
+    },
+  };
+}
 
 export function optimizeCssWithReport(
   options: CreateOptimizedCssOptions,
 ): OptimizedCssReport {
-  const { source, ids } = options;
-  const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
-  const strict = isStrict(options);
-  const safelist = options.safelist ?? [];
-  const { allowlist, preserveFlatpickr } = buildUsage(
-    ids,
-    options.contentClasses,
-  );
-  const report = { removed: 0 };
-
-  const { css } = postcss(
-    createPostcssPlugins(
-      allowlist,
-      preserveAllIBMFonts,
-      preserveFlatpickr,
-      strict,
-      safelist,
-      report,
-    ),
-  ).process(source, { from: options.from });
-
-  return { css, removed: report.removed };
+  const { plugins, finalize } = prepareOptimization(options);
+  const { css } = postcss(plugins).process(options.source, {
+    from: options.from,
+  });
+  return finalize(css);
 }
 
 export async function optimizeCssWithReportAsync(
   options: CreateOptimizedCssOptions,
 ): Promise<OptimizedCssReport> {
-  const { source, ids } = options;
-  const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
-  const strict = isStrict(options);
-  const safelist = options.safelist ?? [];
-  const { allowlist, preserveFlatpickr } = buildUsage(
-    ids,
-    options.contentClasses,
-  );
-  const report = { removed: 0 };
-
-  const { css } = await postcss(
-    createPostcssPlugins(
-      allowlist,
-      preserveAllIBMFonts,
-      preserveFlatpickr,
-      strict,
-      safelist,
-      report,
-    ),
-  ).process(source, { from: options.from });
-
-  return { css, removed: report.removed };
+  const { plugins, finalize } = prepareOptimization(options);
+  const { css } = await postcss(plugins).process(options.source, {
+    from: options.from,
+  });
+  return finalize(css);
 }
 
 export function createOptimizedCss(options: CreateOptimizedCssOptions): string {

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -2,7 +2,7 @@ import type { Plugin } from "vite";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
 import { isSilent, optimizeCssWithReport } from "./create-optimized-css";
-import { printDiff } from "./print-diff";
+import { logOptimizationResult } from "./print-diff";
 import { scanContentClasses } from "./scan-content";
 
 /**
@@ -59,7 +59,11 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
 
         if (file.type === "asset" && isCssFile(id)) {
           const original_css = file.source;
-          const { css: optimized_css, removed } = optimizeCssWithReport({
+          const {
+            css: optimized_css,
+            removed,
+            debug: debugInfo,
+          } = optimizeCssWithReport({
             ...options,
             source: original_css,
             ids,
@@ -69,9 +73,14 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
 
           file.source = optimized_css;
 
-          if (!silent && removed > 0) {
-            printDiff({ original_css, optimized_css, id });
-          }
+          logOptimizationResult({
+            id,
+            original_css,
+            optimized_css,
+            removed,
+            debug: debugInfo,
+            silent,
+          });
         }
       }
     },

--- a/src/plugins/print-diff.ts
+++ b/src/plugins/print-diff.ts
@@ -1,4 +1,7 @@
 import { BITS_DENOM } from "../constants";
+import type { OptimizeCssDebugInfo } from "./create-optimized-css";
+
+const LOG_PREFIX = "[carbon-preprocess-svelte]";
 
 const formatter = new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 });
 
@@ -68,4 +71,50 @@ export function printDiff(props: {
   console.log("Optimized", id);
   console.log("Before:", original_display);
   console.log("After: ", optimized_display, `(-${diff})\n`);
+}
+
+export function printDebug(
+  props: { id: string; removed: number } & OptimizeCssDebugInfo,
+) {
+  const {
+    id,
+    removed,
+    components,
+    allowlistSize,
+    preserveFlatpickr,
+    strict,
+    prunedSample,
+    prunedSampleTruncated,
+  } = props;
+
+  const detected = components.length > 0 ? components.join(", ") : "(none)";
+  const sample = prunedSample.length > 0 ? prunedSample.join(", ") : "(none)";
+  const ellipsis = prunedSampleTruncated ? ", …" : "";
+
+  console.log(`\n${LOG_PREFIX} optimizeCss · ${id}`);
+  console.log(`  components detected: ${detected} (${components.length})`);
+  console.log(
+    `  allowlist classes:   ${allowlistSize} · strict: ${strict} · flatpickr: ${preserveFlatpickr}`,
+  );
+  console.log(`  removed:             ${removed}`);
+  console.log(`  sample pruned:       ${sample}${ellipsis}`);
+}
+
+export function logOptimizationResult(props: {
+  id: string;
+  original_css: Uint8Array | Buffer | string;
+  optimized_css: string;
+  removed: number;
+  debug?: OptimizeCssDebugInfo;
+  silent: boolean;
+}) {
+  const { id, original_css, optimized_css, removed, debug, silent } = props;
+
+  if (debug) {
+    printDebug({ id, removed, ...debug });
+  }
+
+  if (!silent && removed > 0) {
+    printDiff({ original_css, optimized_css, id });
+  }
 }

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -45,6 +45,10 @@ export type StrictCssOptimizerOptions = {
   allowlist: Set<string>;
   preserveFlatpickr: boolean;
   safelist: readonly SafelistEntry[];
+  /**
+   * Optional sink invoked once per pruned selector (for the `debug` summary).
+   */
+  onRemove?: (selector: string) => void;
 };
 
 function getSharedClasses(): Set<string> {
@@ -254,7 +258,7 @@ export function optimizeStrictRule(
   node: Rule,
   options: StrictCssOptimizerOptions,
 ): number {
-  const { allowlist, preserveFlatpickr, safelist } = options;
+  const { allowlist, preserveFlatpickr, safelist, onRemove } = options;
   const selector = node.selector;
 
   if (
@@ -282,6 +286,14 @@ export function optimizeStrictRule(
       shouldKeepSelector(selectee, allowlist)
     );
   });
+
+  if (onRemove && keptSelectors.length < selectors.length) {
+    for (const selectee of selectors) {
+      if (!keptSelectors.includes(selectee)) {
+        onRemove(selectee);
+      }
+    }
+  }
 
   if (keptSelectors.length === 0) {
     node.remove();

--- a/tests/create-optimized-css.test.ts
+++ b/tests/create-optimized-css.test.ts
@@ -1,5 +1,6 @@
 import {
   createOptimizedCss,
+  DEBUG_PRUNED_SAMPLE_CAP,
   optimizeCssWithReport,
 } from "carbon-preprocess-svelte/plugins/create-optimized-css";
 
@@ -516,6 +517,68 @@ button, .flatpickr-day.selected { color: red }`,
       });
       expect(removed).toBe(1);
       expect(css).toEqual(".bx--btn { color: white }");
+    });
+  });
+
+  describe("debug", () => {
+    test("omits debug info when disabled", () => {
+      const { debug } = optimizeCssWithReport({
+        source:
+          ".bx--btn { color: blue }\n.bx--accordion { background: yellow }",
+        ids: ["Button"],
+      });
+      expect(debug).toBeUndefined();
+    });
+
+    test("reports detected components, allowlist, flags, and pruned sample", () => {
+      const { debug } = optimizeCssWithReport({
+        debug: true,
+        source:
+          ".bx--btn { color: blue }\n.bx--accordion { background: yellow }",
+        ids: ["Button", "DataTable"],
+      });
+      expect(debug).toBeDefined();
+      expect(debug?.components).toEqual(["Button", "DataTable"]);
+      expect(debug?.allowlistSize).toBeGreaterThan(0);
+      expect(debug?.strict).toBe(false);
+      expect(debug?.preserveFlatpickr).toBe(false);
+      expect(debug?.prunedSample).toEqual([".bx--accordion"]);
+      expect(debug?.prunedSampleTruncated).toBe(false);
+    });
+
+    test("sets preserveFlatpickr when DatePicker is present", () => {
+      const { debug } = optimizeCssWithReport({
+        debug: true,
+        source: ".bx--btn { color: blue }",
+        ids: ["DatePicker"],
+      });
+      expect(debug?.preserveFlatpickr).toBe(true);
+    });
+
+    test("collects selectors pruned from comma lists in strict mode", () => {
+      const { debug } = optimizeCssWithReport({
+        ...strict,
+        debug: true,
+        source: ".bx--btn, .bx--accordion { color: white }",
+        ids: ["Button"],
+      });
+      expect(debug?.strict).toBe(true);
+      expect(debug?.prunedSample).toEqual([".bx--accordion"]);
+    });
+
+    test("caps the pruned sample at 20 selectors", () => {
+      const source = Array.from(
+        { length: 30 },
+        (_, i) => `.bx--accordion-${i} { color: red }`,
+      ).join("\n");
+      const { debug, removed } = optimizeCssWithReport({
+        debug: true,
+        source,
+        ids: ["Button"],
+      });
+      expect(removed).toBe(30);
+      expect(debug?.prunedSample).toHaveLength(DEBUG_PRUNED_SAMPLE_CAP);
+      expect(debug?.prunedSampleTruncated).toBe(true);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds a `debug` option to `optimizeCss` / `OptimizeCssPlugin` that prints a per-asset summary after optimization: detected components, allowlist size, strict/flatpickr flags, removed count, and a capped sample of pruned selectors. This lets users self-diagnose why styles went missing.

Collection is gated behind `debug`, so the default path pays no cost. Output still prints when `silent` is `true`.

## Usage

```js
// vite.config.js
import { optimizeCss } from "carbon-preprocess-svelte";

export default {
  plugins: [optimizeCss({ debug: true })],
};
```

Logs per CSS asset:

```
[carbon-preprocess-svelte] optimizeCss · assets/index-CU4gbKFa.css
  components detected: Button, DataTable, Modal (3)
  allowlist classes:   214 · strict: false · flatpickr: false
  removed:             1180
  sample pruned:       .bx--accordion, .bx--tabs--scrollable__nav-link, …
```

## Test plan

- [x] `bun run typecheck`
- [x] `bun run lint`
- [x] `bun test tests/create-optimized-css.test.ts` (38 pass)