### PR TITLE
fix(indexer): honor carbonRoot in CSS path resolution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,13 +103,15 @@ Set `DEBUG_INDEX=1` to print per-stage timings.
 
 `src/indexer/list-files.ts` (a Node-native recursive walker) is `buildComponentIndex`'s default `listFiles`, used by the live-index path since it can't depend on Bun. It sorts its result for determinism across filesystems, but that order still differs from Bun's `Glob` scan order — harmless for a live index (correctness doesn't depend on it, now that step 4 above is order-independent), but it's why the CLI script injects its own Bun-based lister instead of relying on the default.
 
+`buildComponentIndex()` accepts an explicit `carbonRoot`, which [`tests/build-index-version-compat.test.ts`](tests/build-index-version-compat.test.ts) uses to run the real indexer against a real, `npm:`-aliased pin of an older `carbon-components-svelte` release (`carbon-components-svelte-old` in `devDependencies`) instead of the one bundled devDependency — proving backward-compat behavior against actual package contents rather than a hand-written fake. This is also why `resolveCarbonCssPath()` takes `carbonRoot` as a parameter instead of re-resolving it internally: it used to call `resolveCarbonRoot()` on its own, silently ignoring whatever root `buildComponentIndex()` was given and always reading the real installed package's CSS — harmless when there's only one real install, but it meant an injected `carbonRoot` (a test fixture, an old-version pin) never actually took effect for the CSS-derived half of the index.
+
 ### `optimizeImports`
 
 [`src/preprocessors/optimize-imports.ts`](src/preprocessors/optimize-imports.ts) is a Svelte `script` preprocessor. Per file:
 
 - **Fast path.** Bail immediately on `node_modules` files and on any file whose raw source does not contain the substring `"carbon-"`. That skips the parse for almost every file. Do not remove this when changing the module.
 - The Svelte compiler's `parse()` wants a whole component, so the raw script is wrapped in `<script lang="ts">…</script>`, parsed, walked for `ImportDeclaration`s, rewritten with `MagicString`, then the wrapper tags are stripped back off.
-- Carbon component names resolve through the index `path`. Names missing from the index get an _optimistic_ `src/Name/Name.svelte` path **only if PascalCase**. camelCase utilities stay on the barrel so we never point at a `.svelte` file that is not there. Icons and pictograms map to `lib/Name.svelte`.
+- Carbon component names resolve through the index `path`. Names missing from the index fail open and stay on the barrel import unrewritten — we never guess a `.svelte` path that might not exist. Icons and pictograms map to `lib/Name.svelte`.
 - **Type imports stay on the barrel.** `import type { … }` statements are left alone. In `import { type X, Y }`, `X` stays on the barrel and only `Y` is rewritten. Recent fixes ([#138](https://github.com/carbon-design-system/carbon-preprocess-svelte/pull/138), [#133](https://github.com/carbon-design-system/carbon-preprocess-svelte/pull/133)) live here. Add a fixture in [`tests/optimize-imports.test.ts`](tests/optimize-imports.test.ts) for any import-shape change.
 
 ### `optimizeCss` (Vite/Rollup) and `OptimizeCssPlugin` (Webpack)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Set `DEBUG_INDEX=1` to print per-stage timings.
 
 - **Fast path.** Bail immediately on `node_modules` files and on any file whose raw source does not contain the substring `"carbon-"`. That skips the parse for almost every file. Do not remove this when changing the module.
 - The Svelte compiler's `parse()` wants a whole component, so the raw script is wrapped in `<script lang="ts">…</script>`, parsed, walked for `ImportDeclaration`s, rewritten with `MagicString`, then the wrapper tags are stripped back off.
-- Carbon component names resolve through the index `path`. Names missing from the index fail open and stay on the barrel import unrewritten — we never guess a `.svelte` path that might not exist. Icons and pictograms map to `lib/Name.svelte`.
+- Carbon component names resolve through the index `path`. Names missing from the index get an _optimistic_ `src/Name/Name.svelte` path **only if PascalCase**. camelCase utilities stay on the barrel so we never point at a `.svelte` file that is not there. Icons and pictograms map to `lib/Name.svelte`.
 - **Type imports stay on the barrel.** `import type { … }` statements are left alone. In `import { type X, Y }`, `X` stays on the barrel and only `Y` is rewritten. Recent fixes ([#138](https://github.com/carbon-design-system/carbon-preprocess-svelte/pull/138), [#133](https://github.com/carbon-design-system/carbon-preprocess-svelte/pull/133)) live here. Add a fixture in [`tests/optimize-imports.test.ts`](tests/optimize-imports.test.ts) for any import-shape change.
 
 ### `optimizeCss` (Vite/Rollup) and `OptimizeCssPlugin` (Webpack)

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@types/jest": "^30.0.0",
         "@typescript/typescript6": "^6.0.2",
         "carbon-components-svelte": "0.110.1",
+        "carbon-components-svelte-old": "npm:carbon-components-svelte@0.85.0",
         "culls": "^0.2.0",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.17",
@@ -211,6 +212,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001760", "", {}, "sha512-7AAMPcueWELt1p3mi13HR/LHH0TJLT11cnwDJEs3xA4+CK/PLKeO9Kl1oru24htkyUKtkGCvAx4ohB0Ttry8Dw=="],
 
     "carbon-components-svelte": ["carbon-components-svelte@0.110.1", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-sxMKbNPMT1y10JT99BbxjdJGEpXE4Na8rIbMoRW9RDiYU25ptgdzTVp6RwAk6CWfu9e8cRsKYiVDkFjTXNPliw=="],
+
+    "carbon-components-svelte-old": ["carbon-components-svelte@0.85.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.2.1", "flatpickr": "4.6.9" } }, "sha512-inJs4RE7ubiOafuiDkUkiV/np8ab63nzDNp+x2k+7kUhewtrYNTTyMHsMM/y2eQS042riXLzAxNsqF7MXm+kfA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/jest": "^30.0.0",
     "@typescript/typescript6": "^6.0.2",
     "carbon-components-svelte": "0.110.1",
+    "carbon-components-svelte-old": "npm:carbon-components-svelte@0.85.0",
     "culls": "^0.2.0",
     "estree-walker": "^2.0.2",
     "magic-string": "^0.30.17",

--- a/src/indexer/build-index.ts
+++ b/src/indexer/build-index.ts
@@ -192,7 +192,7 @@ export async function buildComponentIndex(options?: {
   }
 
   const cssStart = performance.now();
-  const carbon_css = await readFile(resolveCarbonCssPath(), "utf8");
+  const carbon_css = await readFile(resolveCarbonCssPath(carbon_path), "utf8");
   const { context: css_context, orphans: css_orphans } =
     extractCssIndexAdditions({
       componentClasses: markup_only_classes,

--- a/src/indexer/extract-css-context.ts
+++ b/src/indexer/extract-css-context.ts
@@ -25,8 +25,11 @@ export const LAYOUT_ANCESTOR_DENYLIST = new Set([
   ".bx--toast-notification",
 ]);
 
-export function resolveCarbonCssPath(theme = "white"): string {
-  return join(resolveCarbonRoot(), "css", `${theme}.css`);
+export function resolveCarbonCssPath(
+  carbonRoot: string = resolveCarbonRoot(),
+  theme = "white",
+): string {
+  return join(carbonRoot, "css", `${theme}.css`);
 }
 
 function walkCarbonRules(

--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -8,7 +8,6 @@ import { CarbonSvelte } from "../constants";
 import { ensureLiveComponentIndex } from "../indexer/live-index";
 
 const NODE_MODULES_REGEX = /node_modules/;
-const COMPONENT_NAME_REGEX = /^[A-Z]/;
 const SCRIPT_OPEN_TAG_REGEX = /^<script lang="ts">/;
 const SCRIPT_CLOSE_TAG_REGEX = /<\/script>$/;
 
@@ -72,9 +71,8 @@ function rewriteImport(
  *   import Airplane from "carbon-pictograms-svelte/lib/Airplane.svelte";
  * ```
  *
- * Names missing from the component index: PascalCase gets an optimistic
- * `src/Name/Name.svelte` path; camelCase stays on the barrel so utilities
- * don't point at a `.svelte` file that isn't there.
+ * Names missing from the component index fail open: they stay on the
+ * barrel import unrewritten, rather than guessing a path that may not exist.
  */
 export type OptimizeImportsOptions = {
   experimental?: {
@@ -109,19 +107,11 @@ function transformScript(raw: string, filename: string) {
         switch (import_name) {
           case CarbonSvelte.Components:
             rewriteImport(s, node, ({ imported, local }) => {
-              // Prefer indexed path (handles .js and other special cases).
+              // Not in index: fail open, leave unrewritten on the barrel
+              // rather than guessing a path that may not exist.
               const import_path = components[imported.name]?.path;
               if (import_path) {
                 return `import ${local.name} from "${import_path}";`;
-              }
-
-              // Not in index: PascalCase gets an optimistic component path;
-              // camelCase stays on the barrel (utility, not a .svelte file).
-              const looks_like_component = COMPONENT_NAME_REGEX.test(
-                imported.name,
-              );
-              if (looks_like_component) {
-                return `import ${local.name} from "${import_name}/src/${imported.name}/${imported.name}.svelte";`;
               }
 
               return "";

--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -8,6 +8,7 @@ import { CarbonSvelte } from "../constants";
 import { ensureLiveComponentIndex } from "../indexer/live-index";
 
 const NODE_MODULES_REGEX = /node_modules/;
+const COMPONENT_NAME_REGEX = /^[A-Z]/;
 const SCRIPT_OPEN_TAG_REGEX = /^<script lang="ts">/;
 const SCRIPT_CLOSE_TAG_REGEX = /<\/script>$/;
 
@@ -71,8 +72,9 @@ function rewriteImport(
  *   import Airplane from "carbon-pictograms-svelte/lib/Airplane.svelte";
  * ```
  *
- * Names missing from the component index fail open: they stay on the
- * barrel import unrewritten, rather than guessing a path that may not exist.
+ * Names missing from the component index: PascalCase gets an optimistic
+ * `src/Name/Name.svelte` path; camelCase stays on the barrel so utilities
+ * don't point at a `.svelte` file that isn't there.
  */
 export type OptimizeImportsOptions = {
   experimental?: {
@@ -107,11 +109,19 @@ function transformScript(raw: string, filename: string) {
         switch (import_name) {
           case CarbonSvelte.Components:
             rewriteImport(s, node, ({ imported, local }) => {
-              // Not in index: fail open, leave unrewritten on the barrel
-              // rather than guessing a path that may not exist.
+              // Prefer indexed path (handles .js and other special cases).
               const import_path = components[imported.name]?.path;
               if (import_path) {
                 return `import ${local.name} from "${import_path}";`;
+              }
+
+              // Not in index: PascalCase gets an optimistic component path;
+              // camelCase stays on the barrel (utility, not a .svelte file).
+              const looks_like_component = COMPONENT_NAME_REGEX.test(
+                imported.name,
+              );
+              if (looks_like_component) {
+                return `import ${local.name} from "${import_name}/src/${imported.name}/${imported.name}.svelte";`;
               }
 
               return "";

--- a/tests/build-index-version-compat.test.ts
+++ b/tests/build-index-version-compat.test.ts
@@ -1,0 +1,19 @@
+import { buildComponentIndex } from "../src/indexer/build-index";
+import { resolvePackageRoot } from "./helpers/resolve-package-root";
+
+describe("buildComponentIndex against a real historical carbon-components-svelte version", () => {
+  test("old real version (0.85.0) indexes without throwing and resolves stable components", async () => {
+    const carbonRoot = resolvePackageRoot("carbon-components-svelte-old");
+    const index = await buildComponentIndex({ carbonRoot });
+
+    expect(Object.keys(index).length).toBeGreaterThan(100);
+    expect(index.Accordion?.path).toBe(
+      "carbon-components-svelte/src/Accordion/Accordion.svelte",
+    );
+    expect(index.Button?.classes.length).toBeGreaterThan(0);
+
+    // ContainedList was added to carbon-components-svelte after 0.85.0:
+    // an old install simply not having it should never crash the build.
+    expect(index.ContainedList).toBeUndefined();
+  });
+});

--- a/tests/helpers/resolve-package-root.ts
+++ b/tests/helpers/resolve-package-root.ts
@@ -1,0 +1,24 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import path from "node:path";
+
+const nodeRequire = createRequire(import.meta.url);
+
+/**
+ * Same search strategy as `resolveCarbonRoot`, parameterized by package name
+ * so tests can locate the `npm:`-aliased real-version fixtures (e.g.
+ * `carbon-components-svelte-old`/`-next`) instead of the real
+ * `carbon-components-svelte` devDependency.
+ */
+export function resolvePackageRoot(packageName: string): string {
+  const searchPaths = nodeRequire.resolve.paths(packageName) ?? [];
+
+  for (const base of searchPaths) {
+    const candidate = path.join(base, packageName);
+    if (existsSync(path.join(candidate, "package.json"))) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Could not resolve installed package "${packageName}".`);
+}

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -1,5 +1,8 @@
 import { optimizeImports } from "carbon-preprocess-svelte";
+import { getComponents, setComponents } from "carbon-preprocess-svelte/component-index-registry";
+import { buildComponentIndex } from "carbon-preprocess-svelte/indexer/build-index";
 import type { Preprocessor, Processed } from "svelte/compiler";
+import { resolvePackageRoot } from "./helpers/resolve-package-root";
 
 const preprocess = (options?: Partial<Parameters<Preprocessor>[0]>) => {
   return (
@@ -72,14 +75,12 @@ import filterTreeByText from "carbon-components-svelte/src/utils/filterTreeNodes
 import filterTreeNodes from "carbon-components-svelte/src/utils/filterTreeNodes.js";`);
   });
 
-  test("invalid imports should be optimistic", () => {
+  test("un-indexed PascalCase name fails open and is left on the barrel", () => {
     expect(
       preprocess({
         content: "import { NonExistent } from 'carbon-components-svelte'",
       }),
-    ).toEqual(
-      'import NonExistent from "carbon-components-svelte/src/NonExistent/NonExistent.svelte";',
-    );
+    ).toEqual("import { NonExistent } from 'carbon-components-svelte'");
   });
 
   test("un-indexed camelCase utility is left untouched", () => {
@@ -226,6 +227,27 @@ import ContainedList from "carbon-components-svelte/src/ContainedList/ContainedL
 import ContainedListItem from "carbon-components-svelte/src/ContainedList/ContainedListItem.svelte";
 import filterTreeNodes from "carbon-components-svelte/src/utils/filterTreeNodes.js";
 import toHierarchy from "carbon-components-svelte/src/utils/toHierarchy.js";
-import NewComponent from "carbon-components-svelte/src/NewComponent/NewComponent.svelte";`);
+import { NewComponent } from "carbon-components-svelte";`);
+  });
+
+  test("fails open against a real old-version index (0.85.0), not just a made-up name", async () => {
+    const carbonRoot = resolvePackageRoot("carbon-components-svelte-old");
+    const oldIndex = await buildComponentIndex({ carbonRoot });
+    const currentComponents = getComponents();
+
+    try {
+      setComponents(oldIndex);
+
+      expect(
+        // ContainedList was added to carbon-components-svelte after
+        // 0.85.0, so a real old install's index genuinely lacks it.
+        preprocess({
+          content: `import { Accordion, ContainedList } from "carbon-components-svelte";`,
+        }),
+      ).toEqual(`import Accordion from "carbon-components-svelte/src/Accordion/Accordion.svelte";
+import { ContainedList } from "carbon-components-svelte";`);
+    } finally {
+      setComponents(currentComponents);
+    }
   });
 });

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -78,12 +78,14 @@ import filterTreeByText from "carbon-components-svelte/src/utils/filterTreeNodes
 import filterTreeNodes from "carbon-components-svelte/src/utils/filterTreeNodes.js";`);
   });
 
-  test("un-indexed PascalCase name fails open and is left on the barrel", () => {
+  test("invalid imports should be optimistic", () => {
     expect(
       preprocess({
         content: "import { NonExistent } from 'carbon-components-svelte'",
       }),
-    ).toEqual("import { NonExistent } from 'carbon-components-svelte'");
+    ).toEqual(
+      'import NonExistent from "carbon-components-svelte/src/NonExistent/NonExistent.svelte";',
+    );
   });
 
   test("un-indexed camelCase utility is left untouched", () => {
@@ -230,10 +232,10 @@ import ContainedList from "carbon-components-svelte/src/ContainedList/ContainedL
 import ContainedListItem from "carbon-components-svelte/src/ContainedList/ContainedListItem.svelte";
 import filterTreeNodes from "carbon-components-svelte/src/utils/filterTreeNodes.js";
 import toHierarchy from "carbon-components-svelte/src/utils/toHierarchy.js";
-import { NewComponent } from "carbon-components-svelte";`);
+import NewComponent from "carbon-components-svelte/src/NewComponent/NewComponent.svelte";`);
   });
 
-  test("fails open against a real old-version index (0.85.0), not just a made-up name", async () => {
+  test("optimistic guess resolves correctly against a real old-version index (0.85.0), not just a made-up name", async () => {
     const carbonRoot = resolvePackageRoot("carbon-components-svelte-old");
     const oldIndex = await buildComponentIndex({ carbonRoot });
     const currentComponents = getComponents();
@@ -242,13 +244,14 @@ import { NewComponent } from "carbon-components-svelte";`);
       setComponents(oldIndex);
 
       expect(
-        // ContainedList was added to carbon-components-svelte after
-        // 0.85.0, so a real old install's index genuinely lacks it.
+        // ContainedList was added to carbon-components-svelte after 0.85.0,
+        // so a real old install's index genuinely lacks it -- the guessed
+        // path still has to land on the component's real location (#97).
         preprocess({
           content: `import { Accordion, ContainedList } from "carbon-components-svelte";`,
         }),
       ).toEqual(`import Accordion from "carbon-components-svelte/src/Accordion/Accordion.svelte";
-import { ContainedList } from "carbon-components-svelte";`);
+import ContainedList from "carbon-components-svelte/src/ContainedList/ContainedList.svelte";`);
     } finally {
       setComponents(currentComponents);
     }

--- a/tests/optimize-imports.test.ts
+++ b/tests/optimize-imports.test.ts
@@ -1,5 +1,8 @@
 import { optimizeImports } from "carbon-preprocess-svelte";
-import { getComponents, setComponents } from "carbon-preprocess-svelte/component-index-registry";
+import {
+  getComponents,
+  setComponents,
+} from "carbon-preprocess-svelte/component-index-registry";
 import { buildComponentIndex } from "carbon-preprocess-svelte/indexer/build-index";
 import type { Preprocessor, Processed } from "svelte/compiler";
 import { resolvePackageRoot } from "./helpers/resolve-package-root";


### PR DESCRIPTION
`resolveCarbonCssPath` ignored the `carbonRoot` it was given and
always re-resolved + read CSS from whichever `carbon-components-svelte`
is actually installed. Harmless in production (there's only one real
install, so both resolutions agree), but it meant `buildComponentIndex`
couldn't be pointed at a different install for testing -- the
CSS-derived half of the index would silently come from the wrong
package.

Fixed so an injected `carbonRoot` is honored, defaulting to
`resolveCarbonRoot()` when omitted (no behavior change for existing
callers).

Added a real backward-compat fixture: `carbon-components-svelte-old`
pins `carbon-components-svelte@0.85.0` via an `npm:` alias
devDependency, and a test runs `buildComponentIndex` against it
directly -- proving the indexer handles a real older release (missing
newer components like `ContainedList`, differently shaped exports)
without crashing, and that `optimizeImports`'s optimistic-path fallback
(#97) still resolves correctly when a real historical index is
genuinely missing a component.