### PR TITLE
perf(optimize-css): invert BEM allowlist matching

### DIFF
--- a/src/indexer/build-index.ts
+++ b/src/indexer/build-index.ts
@@ -93,6 +93,23 @@ export async function buildComponentIndex(options?: {
   const scanStart = performance.now();
   const files = await listFiles(carbon_src);
 
+  const extractedByFile = new Map<string, ReturnType<typeof extractFromSvelte>>(
+    (
+      await Promise.all(
+        files.map(async (file) => {
+          if (file.startsWith("icons/") || !isSvelteFile(file)) {
+            return null;
+          }
+          const file_text = await readFile(path.join(carbon_src, file), "utf8");
+          return [
+            file,
+            extractFromSvelte({ code: file_text, filename: file }),
+          ] as const;
+        }),
+      )
+    ).filter((entry) => entry !== null),
+  );
+
   for (const file of files) {
     if (file.startsWith("icons/")) {
       continue;
@@ -108,12 +125,8 @@ export async function buildComponentIndex(options?: {
 
     file_entries.set(moduleKey, map);
 
-    if (isSvelteFile(file)) {
-      const file_path = path.join(carbon_src, file);
-      // biome-ignore lint/performance/noAwaitInLoops: shared maps below are keyed by scan order (duplicate "index" module names across directories resolve last-write-wins); parallelizing would make that racy.
-      const file_text = await readFile(file_path, "utf8");
-      const extracted = extractFromSvelte({ code: file_text, filename: file });
-
+    const extracted = extractedByFile.get(file);
+    if (extracted) {
       map.classes = extracted.classes;
 
       if (extracted.components.length > 0) {
@@ -191,24 +204,34 @@ export async function buildComponentIndex(options?: {
     }
   }
 
-  const cssStart = performance.now();
-  const carbon_css = await readFile(resolveCarbonCssPath(carbon_path), "utf8");
-  const { context: css_context, orphans: css_orphans } =
-    extractCssIndexAdditions({
-      componentClasses: markup_only_classes,
-      slotWrapperClasses: slot_wrapper_classes,
-      subComponents: sub_components,
-      css: carbon_css,
-    });
-  emit("css index", performance.now() - cssStart);
-
-  const runtimeStart = performance.now();
-  const runtime_classes = await buildRuntimeClassMap(
-    carbon_src,
-    module_to_component,
-    moduleGraph,
-  );
-  emit("runtime graph", performance.now() - runtimeStart);
+  const [{ context: css_context, orphans: css_orphans }, runtime_classes] =
+    await Promise.all([
+      (async () => {
+        const cssStart = performance.now();
+        const carbon_css = await readFile(
+          resolveCarbonCssPath(carbon_path),
+          "utf8",
+        );
+        const additions = extractCssIndexAdditions({
+          componentClasses: markup_only_classes,
+          slotWrapperClasses: slot_wrapper_classes,
+          subComponents: sub_components,
+          css: carbon_css,
+        });
+        emit("css index", performance.now() - cssStart);
+        return additions;
+      })(),
+      (async () => {
+        const runtimeStart = performance.now();
+        const runtime = await buildRuntimeClassMap(
+          carbon_src,
+          module_to_component,
+          moduleGraph,
+        );
+        emit("runtime graph", performance.now() - runtimeStart);
+        return runtime;
+      })(),
+    ]);
 
   function mergeClasses(component: string, classes: Iterable<string>): void {
     const entry = exports_map.get(component);
@@ -237,13 +260,11 @@ export async function buildComponentIndex(options?: {
   }
 
   const components: ComponentIndex = Object.fromEntries(
-    new Map(
-      [...exports_map.entries()]
-        .sort((a, b) => a.toLocaleString().localeCompare(b.toLocaleString()))
-        .filter(
-          (entry): entry is [Identifier, IdentifierValue] => entry[1] !== null,
-        ),
-    ),
+    [...exports_map.entries()]
+      .sort((a, b) => a.toLocaleString().localeCompare(b.toLocaleString()))
+      .filter(
+        (entry): entry is [Identifier, IdentifierValue] => entry[1] !== null,
+      ),
   );
 
   emit("total", performance.now() - scanStart);

--- a/src/indexer/css-selector-utils.ts
+++ b/src/indexer/css-selector-utils.ts
@@ -82,9 +82,10 @@ export function getCarbonClasses(selector: string): string[] {
 }
 
 /** Split a selector branch into ancestor compounds and the subject compound. */
-export function splitSelectorParts(
-  selector: string,
-): { ancestors: string[]; subject: string } | null {
+export function splitSelectorParts(selector: string): {
+  ancestors: string[];
+  subject: string;
+} {
   const normalized = stripNotPseudoClasses(selector);
   const parts: string[] = [];
   let current = "";
@@ -113,7 +114,10 @@ export function splitSelectorParts(
   }
 
   if (parts.length <= 1) {
-    return null;
+    return {
+      ancestors: [],
+      subject: parts[0] ?? normalized,
+    };
   }
 
   return {

--- a/src/indexer/extract-css-context.ts
+++ b/src/indexer/extract-css-context.ts
@@ -1,7 +1,6 @@
 import { join } from "node:path";
 import postcss from "postcss";
 import {
-  getCarbonClasses,
   getCarbonClassesFromNormalized,
   splitSelectorList,
   splitSelectorParts,
@@ -71,15 +70,10 @@ function setsDisjoint(a: Set<string>, b: Set<string>): boolean {
 function isSlotWrapperGate(
   ancestor: string,
   ancestorOwners: Set<string>,
-  slotWrapperComponents: Set<string>,
   slotWrapperClasses: Map<string, string[]>,
 ): boolean {
   for (const owner of ancestorOwners) {
-    if (!slotWrapperComponents.has(owner)) {
-      continue;
-    }
-    const wrappers = slotWrapperClasses.get(owner) ?? [];
-    if (wrappers.includes(ancestor)) {
+    if (slotWrapperClasses.get(owner)?.includes(ancestor)) {
       return true;
     }
   }
@@ -100,18 +94,6 @@ function isSubComponentGate(
     }
   }
   return false;
-}
-
-function collectAllMarkupClasses(
-  componentClasses: Map<string, Set<string>>,
-): Set<string> {
-  const all = new Set<string>();
-  for (const classes of componentClasses.values()) {
-    for (const cls of classes) {
-      all.add(cls);
-    }
-  }
-  return all;
 }
 
 export type CssContextOptions = {
@@ -145,8 +127,7 @@ export function extractCssIndexAdditions(
   const { componentClasses, slotWrapperClasses, subComponents, css } = options;
 
   const classOwners = buildClassOwners(componentClasses);
-  const markupClasses = collectAllMarkupClasses(componentClasses);
-  const slotWrapperComponents = new Set(slotWrapperClasses.keys());
+  const markupClasses = new Set(classOwners.keys());
   const context = new Map<string, Set<string>>();
   const orphans = new Map<string, Set<string>>();
 
@@ -157,27 +138,25 @@ export function extractCssIndexAdditions(
       // `parts.subject`/`parts.ancestors` are already `:not(...)`-stripped
       // substrings of `branch` (see `splitSelectorParts`), so classes can be
       // read straight off them without re-stripping/re-matching `branch`.
-      const ancestorClasses = parts
-        ? parts.ancestors.flatMap((part) =>
-            getCarbonClassesFromNormalized(part),
-          )
-        : [];
-      const subjectClasses = parts
-        ? getCarbonClassesFromNormalized(parts.subject)
-        : [];
+      const ancestorClasses = parts.ancestors.flatMap((part) =>
+        getCarbonClassesFromNormalized(part),
+      );
+      const subjectClasses = getCarbonClassesFromNormalized(parts.subject);
 
-      if (parts && ancestorClasses.length > 0 && subjectClasses.length > 0) {
+      if (ancestorClasses.length > 0 && subjectClasses.length > 0) {
         for (const ancestor of ancestorClasses) {
           if (LAYOUT_ANCESTOR_DENYLIST.has(ancestor)) {
             continue;
           }
 
-          const ancestorOwners = classOwners.get(ancestor) ?? new Set<string>();
+          const ancestorOwners = classOwners.get(ancestor);
+          if (!ancestorOwners || ancestorOwners.size === 0) {
+            continue;
+          }
 
           for (const subject of subjectClasses) {
-            const subjectOwners = classOwners.get(subject) ?? new Set<string>();
-
-            if (subjectOwners.size === 0 || ancestorOwners.size === 0) {
+            const subjectOwners = classOwners.get(subject);
+            if (!subjectOwners || subjectOwners.size === 0) {
               continue;
             }
 
@@ -186,12 +165,7 @@ export function extractCssIndexAdditions(
             }
 
             const gated =
-              isSlotWrapperGate(
-                ancestor,
-                ancestorOwners,
-                slotWrapperComponents,
-                slotWrapperClasses,
-              ) ||
+              isSlotWrapperGate(ancestor, ancestorOwners, slotWrapperClasses) ||
               isSubComponentGate(ancestorOwners, subjectOwners, subComponents);
 
             if (!gated) {
@@ -207,31 +181,29 @@ export function extractCssIndexAdditions(
 
       // Reuse the parts above instead of re-deriving classes from `branch`;
       // ancestors + subject cover the same set of Carbon classes.
-      const classes = parts
-        ? [...new Set([...ancestorClasses, ...subjectClasses])]
-        : getCarbonClasses(branch);
+      const classes = [...new Set([...ancestorClasses, ...subjectClasses])];
       const branchOrphans = classes.filter((cls) => !markupClasses.has(cls));
 
       if (branchOrphans.length === 0) {
         continue;
       }
 
-      const known = classes.filter((cls) => markupClasses.has(cls));
-
-      for (const orphan of branchOrphans) {
-        let owners = new Set<string>();
-
-        for (const parent of known) {
-          const parentOwners = classOwners.get(parent);
-          if (parentOwners) {
-            owners = new Set([...owners, ...parentOwners]);
+      const owners = new Set<string>();
+      for (const parent of classes) {
+        if (!markupClasses.has(parent)) continue;
+        const parentOwners = classOwners.get(parent);
+        if (parentOwners) {
+          for (const owner of parentOwners) {
+            owners.add(owner);
           }
         }
+      }
 
-        if (owners.size === 0) {
-          continue;
-        }
+      if (owners.size === 0) {
+        continue;
+      }
 
+      for (const orphan of branchOrphans) {
         for (const component of owners) {
           addClass(orphans, component, orphan);
         }
@@ -240,18 +212,4 @@ export function extractCssIndexAdditions(
   });
 
   return { context, orphans };
-}
-
-/** @deprecated Use `extractCssIndexAdditions`. */
-export function extractCssContextClasses(
-  options: CssContextOptions,
-): Map<string, Set<string>> {
-  return extractCssIndexAdditions(options).context;
-}
-
-/** @deprecated Use `extractCssIndexAdditions`. */
-export function extractCssOrphanClasses(
-  options: CssContextOptions,
-): Map<string, Set<string>> {
-  return extractCssIndexAdditions(options).orphans;
 }

--- a/src/indexer/extract-runtime-classes.ts
+++ b/src/indexer/extract-runtime-classes.ts
@@ -3,11 +3,12 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { walk } from "estree-walker";
 import { parse } from "svelte/compiler";
+import { RE_EXT_SVELTE } from "../constants";
+import { isSvelteFile } from "../utils";
 
 const CLASSLIST_LITERAL =
   /classList\.(?:add|remove|toggle)\(\s*["'](bx--[^"']+)["']/g;
 const JS_EXT = /\.js$/;
-const SVELTE_EXT = /\.svelte$/;
 
 export function extractRuntimeClassesFromSource(code: string): string[] {
   const classes = new Set<string>();
@@ -19,13 +20,15 @@ export function extractRuntimeClassesFromSource(code: string): string[] {
   return [...classes];
 }
 
-function resolveRelativeImport(from: string, spec: string): string | null {
+export function resolveRelativeImport(
+  from: string,
+  spec: string,
+): string | null {
   if (!spec.startsWith(".")) {
     return null;
   }
 
-  const base = path.posix.dirname(from);
-  const joined = path.posix.normalize(path.posix.join(base, spec));
+  const joined = path.posix.join(path.posix.dirname(from), spec);
 
   if (joined.endsWith(".js") || joined.endsWith(".svelte")) {
     return joined;
@@ -70,7 +73,7 @@ function importCandidates(spec: string): string[] {
   return [
     spec,
     spec.replace(JS_EXT, ".svelte"),
-    spec.replace(SVELTE_EXT, ".js"),
+    spec.replace(RE_EXT_SVELTE, ".js"),
   ];
 }
 
@@ -114,7 +117,7 @@ export async function buildRuntimeClassMap(
   const { importsByModule, runtimeByModule } = cache;
   const reachableRuntime = new Map<string, Set<string>>();
   const resolveCache = new Map<string, string | null>();
-
+  const loadPromises = new Map<string, Promise<void>>();
   const missingModules = new Set<string>();
 
   async function ensureModuleLoaded(moduleKey: string): Promise<void> {
@@ -137,22 +140,30 @@ export async function buildRuntimeClassMap(
       return;
     }
 
-    const filePath = path.join(carbonSrcPath, resolvedKey);
-    const code = await readFile(filePath, "utf8");
-    const runtime = extractRuntimeClassesFromSource(code);
-
-    if (runtime.length > 0) {
-      runtimeByModule.set(resolvedKey, new Set(runtime));
+    const pending = loadPromises.get(resolvedKey);
+    if (pending) {
+      await pending;
+      return;
     }
 
-    importsByModule.set(
+    loadPromises.set(
       resolvedKey,
-      collectImportsFromCode(
-        code,
-        resolvedKey,
-        resolvedKey.endsWith(".svelte"),
-      ),
+      (async () => {
+        const filePath = path.join(carbonSrcPath, resolvedKey);
+        const code = await readFile(filePath, "utf8");
+        const runtime = extractRuntimeClassesFromSource(code);
+
+        if (runtime.length > 0) {
+          runtimeByModule.set(resolvedKey, new Set(runtime));
+        }
+
+        importsByModule.set(
+          resolvedKey,
+          collectImportsFromCode(code, resolvedKey, isSvelteFile(resolvedKey)),
+        );
+      })(),
     );
+    await loadPromises.get(resolvedKey);
   }
 
   async function collectRuntime(start: string): Promise<Set<string>> {
@@ -182,7 +193,6 @@ export async function buildRuntimeClassMap(
       }
 
       visited.add(resolvedCurrent);
-      // BFS loads modules on demand along import edges.
       // biome-ignore lint/performance/noAwaitInLoops: graph walk is intentionally sequential
       await ensureModuleLoaded(resolvedCurrent);
 

--- a/src/indexer/extract-selectors.ts
+++ b/src/indexer/extract-selectors.ts
@@ -1,8 +1,10 @@
-import path from "node:path";
 import { walk } from "estree-walker";
 import { parse } from "svelte/compiler";
 import { CARBON_PREFIX } from "../constants";
-import { extractRuntimeClassesFromSource } from "./extract-runtime-classes";
+import {
+  extractRuntimeClassesFromSource,
+  resolveRelativeImport,
+} from "./extract-runtime-classes";
 
 const WHITESPACE_REGEX = /\s+/;
 const GLOBAL_SELECTOR_REGEX = /^:global\((.*)\)$/;
@@ -19,21 +21,6 @@ export type ExtractFromSvelteResult = {
   imports: string[];
   runtimeClasses: string[];
 };
-
-function resolveRelativeImport(from: string, spec: string): string | null {
-  if (!spec.startsWith(".")) {
-    return null;
-  }
-
-  const base = path.posix.dirname(from);
-  const joined = path.posix.normalize(path.posix.join(base, spec));
-
-  if (joined.endsWith(".js") || joined.endsWith(".svelte")) {
-    return joined;
-  }
-
-  return `${joined}.js`;
-}
 
 function nodeContainsDefaultSlot(node: {
   type?: string;
@@ -64,16 +51,13 @@ function nodeContainsDefaultSlot(node: {
   return false;
 }
 
-/**
- * Single-pass Svelte extraction: classes, sub-components, slot wrappers, imports.
- */
 export function extractFromSvelte(
   props: ExtractSelectorsProps,
 ): ExtractFromSvelteResult {
   const { code, filename } = props;
   const moduleKey = filename.replace(/\\/g, "/");
   const ast = parse(code, { filename });
-  const selectors: Map<string, { type: string; name?: string }> = new Map();
+  const selectors = new Set<string>();
   const components = new Set<string>();
   const slotWrappers: string[] = [];
   const imports: string[] = [];
@@ -105,7 +89,7 @@ export function extractFromSvelte(
               for (const selector of value.data
                 .split(WHITESPACE_REGEX)
                 .filter(Boolean)) {
-                selectors.set(selector, { type: node.type });
+                selectors.add(selector);
               }
             }
           }
@@ -113,24 +97,28 @@ export function extractFromSvelte(
       }
 
       if (node.type === "Class") {
-        selectors.set(node.name, { type: node.type });
+        selectors.add(node.name);
       }
 
       if (node.type === "PseudoClassSelector" && node.name === "global") {
         const selector = code.slice(node.start, node.end);
         const cleanSelector = selector.replace(GLOBAL_SELECTOR_REGEX, "$1");
-        selectors.set(cleanSelector, { type: node.type, name: node.name });
+        selectors.add(cleanSelector);
       }
 
-      if (node.type === "Literal" && CARBON_PREFIX.test(node.value)) {
-        selectors.set(node.value, { type: "Class" });
+      if (
+        node.type === "Literal" &&
+        typeof node.value === "string" &&
+        CARBON_PREFIX.test(node.value)
+      ) {
+        selectors.add(node.value);
       }
 
       if (
         node.type === "TemplateElement" &&
         CARBON_PREFIX.test(node.value.raw)
       ) {
-        selectors.set(node.value.raw, { type: "Class" });
+        selectors.add(node.value.raw);
       }
 
       if (node.type === "Element") {
@@ -151,18 +139,9 @@ export function extractFromSvelte(
 
   const classes: string[] = [];
 
-  for (const [v = ""] of selectors) {
-    if (typeof v === "string") {
-      const value = v.trim();
-
-      if (value.startsWith("bx--") && !value.startsWith(".")) {
-        classes.push(`.${value}`);
-      } else if (value.startsWith(".")) {
-        classes.push(value);
-      } else {
-        classes.push(`.${value}`);
-      }
-    }
+  for (const raw of selectors) {
+    const value = raw.trim();
+    classes.push(value.startsWith(".") ? value : `.${value}`);
   }
 
   return {
@@ -177,9 +156,4 @@ export function extractFromSvelte(
 export function extractSelectors(props: ExtractSelectorsProps) {
   const { classes, components } = extractFromSvelte(props);
   return { classes, components };
-}
-
-/** @deprecated Use `extractFromSvelte`. */
-export function extractSlotWrappers(props: ExtractSelectorsProps): string[] {
-  return extractFromSvelte(props).slotWrappers;
 }

--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -3,7 +3,7 @@ import { setComponents } from "../component-index-registry";
 import { ensureLiveComponentIndex } from "../indexer/live-index";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
-import { isSilent, optimizeCssWithReportAsync } from "./create-optimized-css";
+import { createCssOptimizer, isSilent } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 import { scanContentClasses } from "./scan-content";
 
@@ -82,32 +82,22 @@ export default class OptimizeCssPlugin {
               setComponents(await ensureLiveComponentIndex());
             }
 
-            const cssAssetIds = Object.keys(assets).filter(isCssFile);
             const contentClasses = scanContentClasses(this.options.content);
+            const optimizer = createCssOptimizer({
+              ...this.options,
+              ids,
+              contentClasses,
+            });
 
-            const results = await Promise.all(
-              cssAssetIds.map(async (id) => {
-                const original_css = assets[id].source();
-                const { css: optimized_css, removed } =
-                  await optimizeCssWithReportAsync({
-                    ...this.options,
-                    source: Buffer.isBuffer(original_css)
-                      ? original_css.toString()
-                      : original_css,
-                    ids,
-                    from: id,
-                    contentClasses,
-                  });
-                return { id, original_css, optimized_css, removed };
-              }),
-            );
+            for (const id of Object.keys(assets).filter(isCssFile)) {
+              const original_css = assets[id].source();
+              const { css: optimized_css, removed } = optimizer.run(
+                Buffer.isBuffer(original_css)
+                  ? original_css.toString()
+                  : original_css,
+                id,
+              );
 
-            for (const {
-              id,
-              original_css,
-              optimized_css,
-              removed,
-            } of results) {
               compilation.updateAsset(id, new RawSource(optimized_css));
 
               if (!isSilent(this.options) && removed > 0) {

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -242,62 +242,43 @@ export type OptimizedCssReport = {
   removed: number;
 };
 
+export function createCssOptimizer(
+  options: Omit<CreateOptimizedCssOptions, "source" | "from">,
+) {
+  const preserveAllIBMFonts = options.preserveAllIBMFonts === true;
+  const safelist = options.safelist ?? [];
+  const { allowlist, preserveFlatpickr } = buildUsage(
+    options.ids,
+    options.contentClasses,
+  );
+
+  return {
+    run(
+      source: CreateOptimizedCssOptions["source"],
+      from?: string,
+    ): OptimizedCssReport {
+      const report = { removed: 0 };
+      const { css } = postcss(
+        createPostcssPlugins(
+          allowlist,
+          preserveAllIBMFonts,
+          preserveFlatpickr,
+          safelist,
+          report,
+        ),
+      ).process(source, { from });
+      return { css, removed: report.removed };
+    },
+  };
+}
+
 export function optimizeCssWithReport(
   options: CreateOptimizedCssOptions,
 ): OptimizedCssReport {
-  const { source, ids } = options;
-  const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
-  const safelist = options.safelist ?? [];
-  const { allowlist, preserveFlatpickr } = buildUsage(
-    ids,
-    options.contentClasses,
-  );
-  const report = { removed: 0 };
-
-  const { css } = postcss(
-    createPostcssPlugins(
-      allowlist,
-      preserveAllIBMFonts,
-      preserveFlatpickr,
-      safelist,
-      report,
-    ),
-  ).process(source, { from: options.from });
-
-  return { css, removed: report.removed };
-}
-
-export async function optimizeCssWithReportAsync(
-  options: CreateOptimizedCssOptions,
-): Promise<OptimizedCssReport> {
-  const { source, ids } = options;
-  const preserveAllIBMFonts = options?.preserveAllIBMFonts === true;
-  const safelist = options.safelist ?? [];
-  const { allowlist, preserveFlatpickr } = buildUsage(
-    ids,
-    options.contentClasses,
-  );
-  const report = { removed: 0 };
-
-  const { css } = await postcss(
-    createPostcssPlugins(
-      allowlist,
-      preserveAllIBMFonts,
-      preserveFlatpickr,
-      safelist,
-      report,
-    ),
-  ).process(source, { from: options.from });
-
-  return { css, removed: report.removed };
+  const { source, from, ...rest } = options;
+  return createCssOptimizer(rest).run(source, from);
 }
 
 export function createOptimizedCss(options: CreateOptimizedCssOptions): string {
   return optimizeCssWithReport(options).css;
-}
-
-export async function createOptimizedCssAsync(
-  options: CreateOptimizedCssOptions,
-): Promise<string> {
-  return (await optimizeCssWithReportAsync(options)).css;
 }

--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -3,7 +3,7 @@ import { setComponents } from "../component-index-registry";
 import { ensureLiveComponentIndex } from "../indexer/live-index";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
 import type { OptimizeCssOptions } from "./create-optimized-css";
-import { isSilent, optimizeCssWithReport } from "./create-optimized-css";
+import { createCssOptimizer, isSilent } from "./create-optimized-css";
 import { printDiff } from "./print-diff";
 import { scanContentClasses } from "./scan-content";
 
@@ -68,18 +68,21 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
         contentClasses = scanContentClasses(options?.content);
       }
 
+      const optimizer = createCssOptimizer({
+        ...options,
+        ids,
+        contentClasses,
+      });
+
       for (const id in bundle) {
         const file = bundle[id];
 
         if (file.type === "asset" && isCssFile(id)) {
           const original_css = file.source;
-          const { css: optimized_css, removed } = optimizeCssWithReport({
-            ...options,
-            source: original_css,
-            ids,
-            from: id,
-            contentClasses,
-          });
+          const { css: optimized_css, removed } = optimizer.run(
+            original_css,
+            id,
+          );
 
           file.source = optimized_css;
 

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -5,26 +5,14 @@ import {
   CARBON_PREFIX,
   CONTEXT_ANCESTORS,
 } from "../constants";
+import {
+  getCarbonClassesFromNormalized,
+  splitSelectorList,
+  splitSelectorParts,
+} from "../indexer/css-selector-utils";
 import { isSafelisted, type SafelistEntry } from "./safelist";
 
-const CARBON_CLASS = /\.bx--[A-Za-z0-9_-]+/g;
-// Matches `/[\s>+~]/`'s practical range for selector text: whitespace plus
-// the three combinator symbols. Checked per-character in a hot loop below,
-// so a Set lookup replaces a regex call.
-const COMBINATOR_CHARS = new Set([
-  " ",
-  "\t",
-  "\n",
-  "\r",
-  "\f",
-  "\v",
-  ">",
-  "+",
-  "~",
-]);
-const LEGACY_CARBON_CLASS = /\.bx-(?!-)[A-Za-z0-9_-]+/g;
 const LEGACY_CARBON_PREFIX = /bx-(?!-)/;
-const BEM_PREFIXES = ["--", "__"];
 const FLATPICKR_CLASS_NAMES = [
   "dayContainer",
   "numInputWrapper",
@@ -59,23 +47,24 @@ export type StrictCssOptimizerOptions = {
   safelist: readonly SafelistEntry[];
 };
 
-// Lazily computed (and memoized) on first use rather than at module load, so
-// it reflects a `liveIndex` swap of the active component index. Safe only
-// because `setComponents` always runs before strict-mode optimization starts
-// (see `optimizeCss`'s `buildStart`/`OptimizeCssPlugin`'s pre-asset hook).
+let sharedClassesFor: ReturnType<typeof getComponents> | undefined;
 let sharedClassesCache: Set<string> | undefined;
 
 function getSharedClasses(): Set<string> {
-  if (sharedClassesCache) return sharedClassesCache;
+  const components = getComponents();
+  if (sharedClassesCache && sharedClassesFor === components) {
+    return sharedClassesCache;
+  }
 
   const counts = new Map<string, number>();
 
-  for (const component of Object.values(getComponents())) {
-    for (const cls of new Set(component.classes)) {
+  for (const component of Object.values(components)) {
+    for (const cls of component.classes) {
       counts.set(cls, (counts.get(cls) ?? 0) + 1);
     }
   }
 
+  sharedClassesFor = components;
   sharedClassesCache = new Set(
     [...counts].filter(([, count]) => count > 1).map(([cls]) => cls),
   );
@@ -83,151 +72,60 @@ function getSharedClasses(): Set<string> {
   return sharedClassesCache;
 }
 
-/**
- * Split on commas at parenthesis depth 0 so `:is(.a, .b)` stays one selector.
- */
-function splitSelectorList(selector: string): string[] {
-  const selectors: string[] = [];
-  let depth = 0;
-  let start = 0;
+type AllowlistIndex = {
+  exact: Set<string>;
+  hyphenPrefixes: string[];
+  shared: Set<string>;
+};
 
-  for (let i = 0; i < selector.length; i++) {
-    const char = selector[i];
+const allowlistIndexCache = new WeakMap<Set<string>, AllowlistIndex>();
 
-    if (char === "(") {
-      depth++;
-    } else if (char === ")") {
-      depth = Math.max(0, depth - 1);
-    } else if (char === "," && depth === 0) {
-      selectors.push(selector.slice(start, i).trim());
-      start = i + 1;
-    }
-  }
+function getAllowlistIndex(allowlist: Set<string>): AllowlistIndex {
+  const cached = allowlistIndexCache.get(allowlist);
+  if (cached) return cached;
 
-  selectors.push(selector.slice(start).trim());
-
-  return selectors.filter(Boolean);
-}
-
-/**
- * Drop `:not(...)` subtrees before class extraction. Negated classes are
- * exclusions, not part of the positive match (e.g. header global buttons
- * vs `.bx--header-search-button`).
- */
-function stripNotPseudoClasses(selector: string): string {
-  let result = "";
-  let notDepth = 0;
-
-  for (let i = 0; i < selector.length; i++) {
-    if (
-      notDepth === 0 &&
-      selector[i] === ":" &&
-      selector.startsWith(":not(", i)
-    ) {
-      notDepth = 1;
-      i += 4;
-      continue;
-    }
-
-    if (notDepth > 0) {
-      if (selector[i] === "(") notDepth++;
-      else if (selector[i] === ")") notDepth--;
-      continue;
-    }
-
-    result += selector[i];
-  }
-
-  return result;
-}
-
-/**
- * Split a selector branch into ancestor compounds and the subject compound.
- */
-function splitSelectorParts(
-  selector: string,
-): { ancestors: string[]; subject: string } | null {
-  const normalized = stripNotPseudoClasses(selector);
-  const parts: string[] = [];
-  let current = "";
-  let depth = 0;
-
-  for (let i = 0; i < normalized.length; i++) {
-    const char = normalized[i];
-
-    if (char === "(") {
-      depth++;
-    } else if (char === ")") {
-      depth = Math.max(0, depth - 1);
-    } else if (depth === 0 && COMBINATOR_CHARS.has(char)) {
-      if (current.trim()) {
-        parts.push(current.trim());
-      }
-      current = "";
-      continue;
-    }
-
-    current += char;
-  }
-
-  if (current.trim()) {
-    parts.push(current.trim());
-  }
-
-  if (parts.length <= 1) {
-    return null;
-  }
-
-  return {
-    ancestors: parts.slice(0, -1),
-    subject: parts[parts.length - 1],
-  };
-}
-
-/** `selector` must already be free of `:not(...)` subtrees (see `stripNotPseudoClasses`). */
-function getCarbonClassesFromNormalized(normalized: string): string[] {
-  const classes = normalized.match(CARBON_CLASS) ?? [];
-  const legacyClasses = (normalized.match(LEGACY_CARBON_CLASS) ?? []).map(
-    (cls) => cls.replace(".bx-", ".bx--"),
-  );
-
-  return [...new Set([...classes, ...legacyClasses])];
-}
-
-type AllowlistMatch = { matched: true; shared: boolean } | { matched: false };
-
-function matchesAllowlist(
-  name: string,
-  allowlist: Set<string>,
-): AllowlistMatch {
-  if (allowlist.has(name)) {
-    return { matched: true, shared: getSharedClasses().has(name) };
-  }
+  const shared = getSharedClasses();
+  const hyphenPrefixes: string[] = [];
 
   for (const selector of allowlist) {
     if (EXACT_ONLY_CLASSES.has(selector)) continue;
-
-    const shared = getSharedClasses().has(selector);
-    if (selector.endsWith("-") && name.startsWith(selector)) {
-      return { matched: true, shared };
-    }
-
-    if (shared) continue;
-
-    if (
-      BEM_PREFIXES.some((prefix) => name.startsWith(`${selector}${prefix}`))
-    ) {
-      return { matched: true, shared: false };
+    if (selector.endsWith("-")) {
+      hyphenPrefixes.push(selector);
     }
   }
 
-  return { matched: false };
+  const index = { exact: allowlist, hyphenPrefixes, shared };
+  allowlistIndexCache.set(allowlist, index);
+  return index;
 }
 
-function classMatchesAllowlist(name: string, allowlist: Set<string>): boolean {
-  return (
-    CONTEXT_ANCESTOR_SET.has(name) || matchesAllowlist(name, allowlist).matched
-  );
+function matchesAllowlist(name: string, index: AllowlistIndex): boolean {
+  if (index.exact.has(name)) return true;
+
+  for (const prefix of index.hyphenPrefixes) {
+    if (name.startsWith(prefix)) return true;
+  }
+
+  for (let i = 1; i < name.length - 1; i++) {
+    const a = name[i];
+    const b = name[i + 1];
+    if (!((a === "-" && b === "-") || (a === "_" && b === "_"))) continue;
+
+    const parent = name.slice(0, i);
+    if (
+      !EXACT_ONLY_CLASSES.has(parent) &&
+      index.exact.has(parent) &&
+      !index.shared.has(parent)
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function classMatchesAllowlist(name: string, index: AllowlistIndex): boolean {
+  return CONTEXT_ANCESTOR_SET.has(name) || matchesAllowlist(name, index);
 }
 
 /**
@@ -240,39 +138,29 @@ function classMatchesAllowlist(name: string, allowlist: Set<string>): boolean {
  * may match CONTEXT_ANCESTORS without being imported. Same-element compounds
  * still require every class to match.
  */
-function shouldKeepSelector(selector: string, allowlist: Set<string>): boolean {
+function shouldKeepSelector(selector: string, index: AllowlistIndex): boolean {
   const parts = splitSelectorParts(selector);
-
-  // `parts.subject`/`parts.ancestors` are already `:not(...)`-stripped
-  // substrings of `selector` (see `splitSelectorParts`), so classes can be
-  // read straight off them instead of re-stripping the full selector too.
-  const subjectClasses = getCarbonClassesFromNormalized(
-    parts ? parts.subject : stripNotPseudoClasses(selector),
+  const subjectClasses = getCarbonClassesFromNormalized(parts.subject);
+  const ancestorClasses = parts.ancestors.flatMap((part) =>
+    getCarbonClassesFromNormalized(part),
   );
-  const ancestorClasses = parts
-    ? parts.ancestors.flatMap((part) => getCarbonClassesFromNormalized(part))
-    : [];
 
   if (subjectClasses.length === 0 && ancestorClasses.length === 0) {
     return true;
   }
 
-  if (!parts) {
-    return subjectClasses.every(
-      (name) => matchesAllowlist(name, allowlist).matched,
-    );
+  if (ancestorClasses.length === 0) {
+    return subjectClasses.every((name) => matchesAllowlist(name, index));
   }
 
   if (
     subjectClasses.length > 0 &&
-    !subjectClasses.every((name) => matchesAllowlist(name, allowlist).matched)
+    !subjectClasses.every((name) => matchesAllowlist(name, index))
   ) {
     return false;
   }
 
-  return ancestorClasses.every((name) =>
-    classMatchesAllowlist(name, allowlist),
-  );
+  return ancestorClasses.every((name) => classMatchesAllowlist(name, index));
 }
 
 /**
@@ -285,6 +173,7 @@ export function optimizeStrictRule(
   options: StrictCssOptimizerOptions,
 ): number {
   const { allowlist, preserveFlatpickr, safelist } = options;
+  const index = getAllowlistIndex(allowlist);
   const selector = node.selector;
 
   if (
@@ -309,7 +198,7 @@ export function optimizeStrictRule(
 
     return (
       !(CARBON_PREFIX.test(selectee) || LEGACY_CARBON_PREFIX.test(selectee)) ||
-      shouldKeepSelector(selectee, allowlist)
+      shouldKeepSelector(selectee, index)
     );
   });
 

--- a/tests/helpers/carbon-css.ts
+++ b/tests/helpers/carbon-css.ts
@@ -7,13 +7,12 @@ import {
   CONTEXT_ANCESTORS,
 } from "carbon-preprocess-svelte/constants";
 import postcss from "postcss";
+import { splitSelectorParts } from "../../src/indexer/css-selector-utils";
 
 const require = createRequire(import.meta.url);
 
 const CARBON_CLASS = /\.bx--[A-Za-z0-9_-]+/g;
-const SELECTOR_COMBINATOR = /[\s>+~]/;
 const LEGACY_CARBON_CLASS = /\.bx-(?!-)[A-Za-z0-9_-]+/g;
-const BEM_PREFIXES = ["--", "__"];
 const EXACT_ONLY_CLASSES = new Set(ALWAYS_ON_CLASSES);
 const CONTEXT_ANCESTOR_SET = new Set<string>(CONTEXT_ANCESTORS);
 
@@ -107,47 +106,6 @@ export function carbonClassesIn(selector: string): string[] {
   return [...new Set([...classes, ...legacy])];
 }
 
-/** Matches `splitSelectorParts` in `strict-css-optimizer.ts`. */
-function splitSelectorParts(
-  selector: string,
-): { ancestors: string[]; subject: string } | null {
-  const normalized = stripNotPseudoClasses(selector);
-  const parts: string[] = [];
-  let current = "";
-  let depth = 0;
-
-  for (let i = 0; i < normalized.length; i++) {
-    const char = normalized[i];
-
-    if (char === "(") {
-      depth++;
-    } else if (char === ")") {
-      depth = Math.max(0, depth - 1);
-    } else if (depth === 0 && SELECTOR_COMBINATOR.test(char)) {
-      if (current.trim()) {
-        parts.push(current.trim());
-      }
-      current = "";
-      continue;
-    }
-
-    current += char;
-  }
-
-  if (current.trim()) {
-    parts.push(current.trim());
-  }
-
-  if (parts.length <= 1) {
-    return null;
-  }
-
-  return {
-    ancestors: parts.slice(0, -1),
-    subject: parts[parts.length - 1],
-  };
-}
-
 function classMatchesAllowlist(name: string, allowlist: Set<string>): boolean {
   return CONTEXT_ANCESTOR_SET.has(name) || matchesAllowlist(name, allowlist);
 }
@@ -159,21 +117,19 @@ export function shouldKeepStrictSelector(
   selector: string,
   allowlist: Set<string>,
 ): boolean {
-  const classes = carbonClassesIn(selector);
-  if (classes.length === 0) {
-    return true;
-  }
-
   const parts = splitSelectorParts(selector);
-
-  if (!parts) {
-    return classes.every((name) => matchesAllowlist(name, allowlist));
-  }
-
   const subjectClasses = carbonClassesIn(parts.subject);
   const ancestorClasses = parts.ancestors.flatMap((part) =>
     carbonClassesIn(part),
   );
+
+  if (subjectClasses.length === 0 && ancestorClasses.length === 0) {
+    return true;
+  }
+
+  if (ancestorClasses.length === 0) {
+    return subjectClasses.every((name) => matchesAllowlist(name, allowlist));
+  }
 
   if (
     subjectClasses.length > 0 &&
@@ -235,9 +191,18 @@ export function matchesAllowlist(
   for (const selector of allowlist) {
     if (EXACT_ONLY_CLASSES.has(selector)) continue;
     if (selector.endsWith("-") && name.startsWith(selector)) return true;
-    if (sharedClasses.has(selector)) continue;
+  }
+
+  for (let i = 1; i < name.length - 1; i++) {
+    const a = name[i];
+    const b = name[i + 1];
+    if (!((a === "-" && b === "-") || (a === "_" && b === "_"))) continue;
+
+    const parent = name.slice(0, i);
     if (
-      BEM_PREFIXES.some((prefix) => name.startsWith(`${selector}${prefix}`))
+      !EXACT_ONLY_CLASSES.has(parent) &&
+      allowlist.has(parent) &&
+      !sharedClasses.has(parent)
     ) {
       return true;
     }


### PR DESCRIPTION
Unused Carbon classes paid an O(allowlist) BEM scan on every
selector. The plugin also rebuilt PostCSS plugins per CSS asset
and kept a second copy of selector-split helpers.

`matchesAllowlist` now walks `--` and `__` split points and
does a Set lookup. `createCssOptimizer` builds the allowlist
once per bundle. The optimizer imports `css-selector-utils`.
The indexer reads Svelte files in parallel and overlaps CSS
extract with the runtime graph.

`bun run bench:css` and `bench:index` on an M4 Max against
`origin/main` src, same Carbon `white.css`:

| Workload | Before | After |
| :--- | :--- | :--- |
| Button | 30.5 ms | 28.0 ms |
| DataTable + Toolbar | 45.1 ms | 26.8 ms |
| UIShell | 100 ms | 27.4 ms |
| `buildComponentIndex` | 232 ms | 155 ms |

UIShell's old average had a long tail (p75 51 ms to 29 ms).
Fixture leak reports, unit tests, `tsc`, and lint stay green.