### PR TITLE
chore(deps): bump ostia to 0.2.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "culls": "^0.2.0",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.17",
-        "ostia": "^0.1.7",
+        "ostia": "^0.2.0",
         "postcss": "^8.5.15",
         "postcss-discard-empty": "^8.0.5",
         "svelte": "^5.56.10",
@@ -322,7 +322,7 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
-    "ostia": ["ostia@0.1.7", "", { "bin": { "ostia": "cli.js" } }, "sha512-TVrDTh9H/1xzROyNYQONNfIyT9w8Ki/1RDhJ3Awj8KB0tN8Qbnktqwt0cdElQLiP3TFuq6sTJ4XjTZS05PIDhg=="],
+    "ostia": ["ostia@0.2.0", "", { "bin": { "ostia": "cli.js" } }, "sha512-X+kqTYBmK7r0RgLLy5kqXFxrg0drR39ldOW9+i4H2Nnz4xU1dozsrqaz6pxm6wvlcAoSMIGKWFCYMWMkH+4rmA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "culls": "^0.2.0",
     "estree-walker": "^2.0.2",
     "magic-string": "^0.30.17",
-    "ostia": "^0.1.7",
+    "ostia": "^0.2.0",
     "postcss": "^8.5.15",
     "postcss-discard-empty": "^8.0.5",
     "svelte": "^5.56.10",


### PR DESCRIPTION
This is a breaking release, but the repo only uses group()/task()/bench(),
which are unchanged, so no source changes were needed beyond the version
bump.