### PR TITLE
refactor: simplify indexer helpers and drop unused exports

### DIFF
--- a/scripts/bundle-dts.ts
+++ b/scripts/bundle-dts.ts
@@ -537,10 +537,27 @@ function getLeadingComment(stmt: ts.Statement, sf: ts.SourceFile): string {
   return `${ranges.map((r) => fullText.slice(r.pos, r.end)).join("\n")}\n`;
 }
 
+/** Keyed on the per-build `emitted` map so caches never outlive a build. */
+const parsedDts = new WeakMap<
+  Map<string, string>,
+  Map<string, ts.SourceFile>
+>();
+
 function parseDts(file: string, emitted: Map<string, string>): ts.SourceFile {
+  let cache = parsedDts.get(emitted);
+  if (!cache) {
+    cache = new Map();
+    parsedDts.set(emitted, cache);
+  }
+
+  const cached = cache.get(file);
+  if (cached) return cached;
+
   const text = emitted.get(file);
   if (text === undefined) throw new Error(`missing emit for ${file}`);
-  return ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+  cache.set(file, sf);
+  return sf;
 }
 
 function isRelative(spec: string): boolean {

--- a/src/indexer/build-index.ts
+++ b/src/indexer/build-index.ts
@@ -261,7 +261,7 @@ export async function buildComponentIndex(options?: {
 
   const components: ComponentIndex = Object.fromEntries(
     [...exports_map.entries()]
-      .sort((a, b) => a.toLocaleString().localeCompare(b.toLocaleString()))
+      .sort((a, b) => a[0].localeCompare(b[0]))
       .filter(
         (entry): entry is [Identifier, IdentifierValue] => entry[1] !== null,
       ),

--- a/src/indexer/css-selector-utils.ts
+++ b/src/indexer/css-selector-utils.ts
@@ -40,7 +40,7 @@ export function splitSelectorList(selector: string): string[] {
 }
 
 /** Drop `:not(...)` subtrees before class extraction. */
-export function stripNotPseudoClasses(selector: string): string {
+function stripNotPseudoClasses(selector: string): string {
   let result = "";
   let notDepth = 0;
 
@@ -75,10 +75,6 @@ export function getCarbonClassesFromNormalized(normalized: string): string[] {
   );
 
   return [...new Set([...classes, ...legacyClasses])];
-}
-
-export function getCarbonClasses(selector: string): string[] {
-  return getCarbonClassesFromNormalized(stripNotPseudoClasses(selector));
 }
 
 /** Split a selector branch into ancestor compounds and the subject compound. */

--- a/src/indexer/css-selector-utils.ts
+++ b/src/indexer/css-selector-utils.ts
@@ -17,6 +17,10 @@ const COMBINATOR_CHARS = new Set([
 
 /** Split on commas at parenthesis depth 0. */
 export function splitSelectorList(selector: string): string[] {
+  if (!selector.includes(",")) {
+    return [selector.trim()].filter(Boolean);
+  }
+
   const selectors: string[] = [];
   let depth = 0;
   let start = 0;
@@ -41,34 +45,34 @@ export function splitSelectorList(selector: string): string[] {
 
 /** Drop `:not(...)` subtrees before class extraction. */
 function stripNotPseudoClasses(selector: string): string {
+  let index = selector.indexOf(":not(");
+  if (index === -1) return selector;
+
   let result = "";
-  let notDepth = 0;
+  let start = 0;
 
-  for (let i = 0; i < selector.length; i++) {
-    if (
-      notDepth === 0 &&
-      selector[i] === ":" &&
-      selector.startsWith(":not(", i)
-    ) {
-      notDepth = 1;
-      i += 4;
-      continue;
+  while (index !== -1) {
+    result += selector.slice(start, index);
+
+    // Skip to just past the parenthesis that closes this `:not(`.
+    let depth = 1;
+    let i = index + 5;
+    for (; i < selector.length && depth > 0; i++) {
+      if (selector[i] === "(") depth++;
+      else if (selector[i] === ")") depth--;
     }
 
-    if (notDepth > 0) {
-      if (selector[i] === "(") notDepth++;
-      else if (selector[i] === ")") notDepth--;
-      continue;
-    }
-
-    result += selector[i];
+    start = i;
+    index = selector.indexOf(":not(", start);
   }
 
-  return result;
+  return result + selector.slice(start);
 }
 
 /** `normalized` must already be free of `:not(...)` subtrees. */
 export function getCarbonClassesFromNormalized(normalized: string): string[] {
+  if (!normalized.includes(".bx-")) return [];
+
   const classes = normalized.match(CARBON_CLASS) ?? [];
   const legacyClasses = (normalized.match(LEGACY_CARBON_CLASS) ?? []).map(
     (cls) => cls.replace(".bx-", ".bx--"),
@@ -84,8 +88,13 @@ export function splitSelectorParts(selector: string): {
 } {
   const normalized = stripNotPseudoClasses(selector);
   const parts: string[] = [];
-  let current = "";
   let depth = 0;
+  let start = 0;
+
+  const pushPart = (end: number) => {
+    const part = normalized.slice(start, end).trim();
+    if (part) parts.push(part);
+  };
 
   for (let i = 0; i < normalized.length; i++) {
     const char = normalized[i];
@@ -95,19 +104,12 @@ export function splitSelectorParts(selector: string): {
     } else if (char === ")") {
       depth = Math.max(0, depth - 1);
     } else if (depth === 0 && COMBINATOR_CHARS.has(char)) {
-      if (current.trim()) {
-        parts.push(current.trim());
-      }
-      current = "";
-      continue;
+      pushPart(i);
+      start = i + 1;
     }
-
-    current += char;
   }
 
-  if (current.trim()) {
-    parts.push(current.trim());
-  }
+  pushPart(normalized.length);
 
   if (parts.length <= 1) {
     return {

--- a/src/indexer/extract-css-context.ts
+++ b/src/indexer/extract-css-context.ts
@@ -8,7 +8,7 @@ import {
 import { resolveCarbonRoot } from "./resolve-carbon-root";
 
 /** Ancestors we must never auto-propagate (strict bundle pairs stay manual). */
-export const LAYOUT_ANCESTOR_DENYLIST = new Set([
+const LAYOUT_ANCESTOR_DENYLIST = new Set([
   ".bx--modal",
   ".bx--form--fluid",
   ".bx--pagination",
@@ -42,6 +42,16 @@ function walkCarbonRules(
   });
 }
 
+function addToSet(
+  map: Map<string, Set<string>>,
+  key: string,
+  value: string,
+): void {
+  const set = map.get(key) ?? new Set<string>();
+  set.add(value);
+  map.set(key, set);
+}
+
 function buildClassOwners(
   componentClasses: Map<string, Set<string>>,
 ): Map<string, Set<string>> {
@@ -49,9 +59,7 @@ function buildClassOwners(
 
   for (const [component, classes] of componentClasses.entries()) {
     for (const cls of classes) {
-      const set = owners.get(cls) ?? new Set<string>();
-      set.add(component);
-      owners.set(cls, set);
+      addToSet(owners, cls, component);
     }
   }
 
@@ -108,16 +116,6 @@ export type CssIndexAdditions = {
   orphans: Map<string, Set<string>>;
 };
 
-function addClass(
-  additions: Map<string, Set<string>>,
-  component: string,
-  cls: string,
-): void {
-  const set = additions.get(component) ?? new Set<string>();
-  set.add(cls);
-  additions.set(component, set);
-}
-
 /**
  * Walk Carbon CSS once and infer context ancestors plus CSS-orphan classes.
  */
@@ -173,7 +171,7 @@ export function extractCssIndexAdditions(
             }
 
             for (const component of subjectOwners) {
-              addClass(context, component, ancestor);
+              addToSet(context, component, ancestor);
             }
           }
         }
@@ -205,7 +203,7 @@ export function extractCssIndexAdditions(
 
       for (const orphan of branchOrphans) {
         for (const component of owners) {
-          addClass(orphans, component, orphan);
+          addToSet(orphans, component, orphan);
         }
       }
     }

--- a/src/indexer/extract-runtime-classes.ts
+++ b/src/indexer/extract-runtime-classes.ts
@@ -37,26 +37,39 @@ export function resolveRelativeImport(
   return `${joined}.js`;
 }
 
+/**
+ * `import … from "…"` / `import "…"` sources in a plain JS module. Carbon's
+ * utilities are simple enough that this matches a full Svelte-parser walk
+ * exactly (checked against every module in carbon-components-svelte) at
+ * ~1% of the cost. `.svelte` modules still go through the parser.
+ */
+const JS_IMPORT_SOURCE =
+  /\bimport\s*(?:[\w$*{}\s,]+?\s*from\s*)?["']([^"']+)["']/g;
+
 function collectImportsFromCode(
   code: string,
   moduleKey: string,
   isSvelte: boolean,
 ): string[] {
-  const ast = isSvelte
-    ? parse(code, { filename: moduleKey })
-    : parse(`<script>${code}</script>`, { filename: moduleKey });
   const imports: string[] = [];
+  const add = (spec: string) => {
+    const resolved = resolveRelativeImport(moduleKey, spec);
+    if (resolved) {
+      imports.push(resolved);
+    }
+  };
 
-  walk(ast, {
+  if (!isSvelte) {
+    for (const match of code.matchAll(JS_IMPORT_SOURCE)) {
+      add(match[1]);
+    }
+    return imports;
+  }
+
+  walk(parse(code, { filename: moduleKey }), {
     enter(node) {
       if (node.type === "ImportDeclaration" && node.source?.value) {
-        const resolved = resolveRelativeImport(
-          moduleKey,
-          String(node.source.value),
-        );
-        if (resolved) {
-          imports.push(resolved);
-        }
+        add(String(node.source.value));
       }
     },
   });

--- a/src/indexer/extract-runtime-classes.ts
+++ b/src/indexer/extract-runtime-classes.ts
@@ -146,24 +146,22 @@ export async function buildRuntimeClassMap(
       return;
     }
 
-    loadPromises.set(
-      resolvedKey,
-      (async () => {
-        const filePath = path.join(carbonSrcPath, resolvedKey);
-        const code = await readFile(filePath, "utf8");
-        const runtime = extractRuntimeClassesFromSource(code);
+    const load = (async () => {
+      const filePath = path.join(carbonSrcPath, resolvedKey);
+      const code = await readFile(filePath, "utf8");
+      const runtime = extractRuntimeClassesFromSource(code);
 
-        if (runtime.length > 0) {
-          runtimeByModule.set(resolvedKey, new Set(runtime));
-        }
+      if (runtime.length > 0) {
+        runtimeByModule.set(resolvedKey, new Set(runtime));
+      }
 
-        importsByModule.set(
-          resolvedKey,
-          collectImportsFromCode(code, resolvedKey, isSvelteFile(resolvedKey)),
-        );
-      })(),
-    );
-    await loadPromises.get(resolvedKey);
+      importsByModule.set(
+        resolvedKey,
+        collectImportsFromCode(code, resolvedKey, isSvelteFile(resolvedKey)),
+      );
+    })();
+    loadPromises.set(resolvedKey, load);
+    await load;
   }
 
   async function collectRuntime(start: string): Promise<Set<string>> {

--- a/src/indexer/extract-selectors.ts
+++ b/src/indexer/extract-selectors.ts
@@ -82,16 +82,13 @@ export function extractFromSvelte(
         }
       }
 
-      if (node.type === "Attribute" && node.name === "class") {
-        if (node.value) {
-          for (const value of node.value) {
-            if (value.type === "Text") {
-              for (const selector of value.data
-                .split(WHITESPACE_REGEX)
-                .filter(Boolean)) {
-                selectors.add(selector);
-              }
-            }
+      if (node.type === "Attribute" && node.name === "class" && node.value) {
+        for (const value of node.value) {
+          if (value.type !== "Text") continue;
+          for (const selector of value.data
+            .split(WHITESPACE_REGEX)
+            .filter(Boolean)) {
+            selectors.add(selector);
           }
         }
       }

--- a/src/indexer/live-index.ts
+++ b/src/indexer/live-index.ts
@@ -47,7 +47,7 @@ async function writeCache(
  * keyed by the installed version so a Carbon bump invalidates the cache
  * automatically (a new version simply misses and rebuilds).
  */
-export async function resolveLiveComponentIndex(): Promise<ComponentIndex> {
+async function resolveLiveComponentIndex(): Promise<ComponentIndex> {
   const carbonRoot = resolveCarbonRoot();
   const version = await readCarbonVersion(carbonRoot);
   const cacheDir = path.join(path.dirname(carbonRoot), CACHE_DIRNAME);

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -6,6 +6,7 @@ import { getComponents } from "../component-index-registry";
 import { ALWAYS_ON_CLASSES } from "../constants";
 import type { SafelistEntry } from "./safelist";
 import {
+  hasOptimizableCss,
   optimizeStrictAtRule,
   optimizeStrictRule,
 } from "./strict-css-optimizer";
@@ -242,6 +243,16 @@ export type OptimizedCssReport = {
   removed: number;
 };
 
+function toCssString(source: CreateOptimizedCssOptions["source"]): string {
+  if (typeof source === "string") return source;
+  // Same decoding PostCSS applies to a Buffer, without copying the bytes.
+  return Buffer.from(
+    source.buffer,
+    source.byteOffset,
+    source.byteLength,
+  ).toString();
+}
+
 export function createCssOptimizer(
   options: Omit<CreateOptimizedCssOptions, "source" | "from">,
 ) {
@@ -257,6 +268,15 @@ export function createCssOptimizer(
       source: CreateOptimizedCssOptions["source"],
       from?: string,
     ): OptimizedCssReport {
+      // Bundlers hand every CSS asset to the plugin, including per-route
+      // chunks with no Carbon styles at all. Parsing and re-serializing
+      // those is pure overhead, so skip PostCSS unless something removable
+      // could be present.
+      const input = toCssString(source);
+      if (!hasOptimizableCss(input)) {
+        return { css: input, removed: 0 };
+      }
+
       const report = { removed: 0 };
       const { css } = postcss(
         createPostcssPlugins(
@@ -266,7 +286,7 @@ export function createCssOptimizer(
           safelist,
           report,
         ),
-      ).process(source, { from });
+      ).process(input, { from });
       return { css, removed: report.removed };
     },
   };

--- a/src/plugins/print-diff.ts
+++ b/src/plugins/print-diff.ts
@@ -30,7 +30,7 @@ function stringSizeInKB(str: string) {
 }
 
 function padIfNeeded(a: string, b: string) {
-  return a.length > b.length ? a : a.padStart(b.length, " ");
+  return a.padStart(b.length, " ");
 }
 
 /**

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -38,8 +38,20 @@ const FLATPICKR_SELECTOR = new RegExp(
   `\\.(?:flatpickr-[A-Za-z0-9_-]+|${FLATPICKR_CLASS_NAMES.join("|")})(?![A-Za-z0-9_-])`,
 );
 const FLATPICKR_KEYFRAMES = new Set(["fpFadeInDown"]);
+/**
+ * Anything the optimizer could remove: Carbon (`bx-`) selectors, flatpickr
+ * selectors and keyframes, and IBM Plex `@font-face` rules. A stylesheet
+ * with none of these is returned untouched without a PostCSS round-trip.
+ */
+const OPTIMIZABLE_CSS = new RegExp(
+  `bx-|flatpickr|IBM Plex|${[...FLATPICKR_KEYFRAMES, ...FLATPICKR_CLASS_NAMES].join("|")}`,
+);
 const EXACT_ONLY_CLASSES = new Set(ALWAYS_ON_CLASSES);
 const CONTEXT_ANCESTOR_SET = new Set<string>(CONTEXT_ANCESTORS);
+
+export function hasOptimizableCss(css: string): boolean {
+  return OPTIMIZABLE_CSS.test(css);
+}
 
 export type StrictCssOptimizerOptions = {
   allowlist: Set<string>;

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -76,6 +76,12 @@ type AllowlistIndex = {
   exact: Set<string>;
   hyphenPrefixes: string[];
   shared: Set<string>;
+  /**
+   * Per-class verdicts. Carbon's stylesheet repeats the same ~1.3k class
+   * names across ~14k selector positions, so the prefix/parent walk in
+   * `matchesAllowlist` only needs to run once per distinct class.
+   */
+  verdicts: Map<string, boolean>;
 };
 
 const allowlistIndexCache = new WeakMap<Set<string>, AllowlistIndex>();
@@ -94,12 +100,26 @@ function getAllowlistIndex(allowlist: Set<string>): AllowlistIndex {
     }
   }
 
-  const index = { exact: allowlist, hyphenPrefixes, shared };
+  const index = {
+    exact: allowlist,
+    hyphenPrefixes,
+    shared,
+    verdicts: new Map<string, boolean>(),
+  };
   allowlistIndexCache.set(allowlist, index);
   return index;
 }
 
 function matchesAllowlist(name: string, index: AllowlistIndex): boolean {
+  const cached = index.verdicts.get(name);
+  if (cached !== undefined) return cached;
+
+  const verdict = computeAllowlistMatch(name, index);
+  index.verdicts.set(name, verdict);
+  return verdict;
+}
+
+function computeAllowlistMatch(name: string, index: AllowlistIndex): boolean {
   if (index.exact.has(name)) return true;
 
   for (const prefix of index.hyphenPrefixes) {

--- a/tests/helpers/carbon-css.ts
+++ b/tests/helpers/carbon-css.ts
@@ -94,7 +94,8 @@ function stripNotPseudoClasses(selector: string): string {
 
 /**
  * Pull `.bx--*` tokens from a selector. Normalizes legacy `.bx-` to `.bx--`.
- * Matches `getCarbonClasses` in the source so drift shows up in tests.
+ * Matches the source's `:not()` stripping + `getCarbonClassesFromNormalized`
+ * so drift shows up in tests.
  */
 export function carbonClassesIn(selector: string): string[] {
   const normalized = stripNotPseudoClasses(selector);


### PR DESCRIPTION
A cleanup pass over `src/` and `scripts/` followed by four perf commits
against the paths covered by `bench/`. Behavior is unchanged except that
CSS assets with nothing removable no longer go through
`postcss-discard-empty`, so their empty rules survive.

## Benchmark

Paired min-of-N timings on an M2, swapping each file to HEAD and back in
the same process because the machine was too loaded for clean `ostia`
tables. Rerun `bun run bench` on a quiet box for proper before/after.

| Path                                       | Before  | After   |
| ------------------------------------------ | ------- | ------- |
| `optimizeCssWithReport`, Carbon CSS, Button | ~39 ms  | ~28 ms  |
| `splitSelectorParts` over all branches     | 9.4 ms  | 2.5 ms  |
| allowlist verdicts per stylesheet          | 1.6 ms  | 0.6 ms  |
| 92 KB non-Carbon CSS asset                 | ~15 ms  | ~0.2 ms |
| `buildComponentIndex` runtime-graph phase  | ~44 ms  | ~34 ms  |
| `buildComponentIndex` total                | ~202 ms | ~192 ms |

The regex import scanner was checked against the Svelte parser on all
149 Carbon JS modules with no mismatches, and every commit regenerates
`component-index.ts` byte for byte.
