### PR TITLE
chore(lint): add vcs-scoped changed-files fix script

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
   "assist": {
     "actions": {
       "source": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
     "lint:fix": "biome check --write --unsafe .",
+    "lint:fix:changed": "biome check --write --unsafe --changed --no-errors-on-unmatched .",
     "upgrade-examples": "bun scripts/upgrade-examples.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
Repo is small enough that a full biome pass is already fast, but this
adds the vcs ignore-file wiring and a diff-scoped fix script so both
stay cheap as generated output grows, mirroring
metonym/svelte-highlight#523.