### PR TITLE
chore(bench): upgrade ostia to 0.2.3

### DIFF
--- a/bench/build-index.bench.ts
+++ b/bench/build-index.bench.ts
@@ -13,8 +13,9 @@ group("buildComponentIndex (full scan)", () => {
 
 // Bonus: one-off phase breakdown (scan / css index / runtime graph / total) to
 // help point at *where* time goes, not just the aggregate.
-// Note: ostia has no in-suite run(), so this block executes during suite import
-// (before the benchmark table below is printed), not after like it did with mitata.
+// Note: this suite runs via the `ostia bench` CLI (not ostia's in-file run()),
+// so this block executes during suite import, before the benchmark table below
+// is printed, not after like it did with mitata.
 const timings: Record<string, number> = {};
 await buildComponentIndex({
   onTiming: (label, ms) => {

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "culls": "^0.2.0",
         "estree-walker": "^2.0.2",
         "magic-string": "^0.30.17",
-        "ostia": "^0.2.0",
+        "ostia": "^0.2.3",
         "postcss": "^8.5.15",
         "postcss-discard-empty": "^8.0.5",
         "svelte": "^5.56.10",
@@ -322,7 +322,7 @@
 
     "node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
-    "ostia": ["ostia@0.2.0", "", { "bin": { "ostia": "cli.js" } }, "sha512-X+kqTYBmK7r0RgLLy5kqXFxrg0drR39ldOW9+i4H2Nnz4xU1dozsrqaz6pxm6wvlcAoSMIGKWFCYMWMkH+4rmA=="],
+    "ostia": ["ostia@0.2.3", "", { "bin": { "ostia": "cli.js" } }, "sha512-o/zO4BQDn9RKmo3RYjmLvohT4/41RRBK/1pIgAeZ6ok98g1386ywS9JAgkzJRPXkXxYkvemIm4E8dnfuDBEHRw=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "culls": "^0.2.0",
     "estree-walker": "^2.0.2",
     "magic-string": "^0.30.17",
-    "ostia": "^0.2.0",
+    "ostia": "^0.2.3",
     "postcss": "^8.5.15",
     "postcss-discard-empty": "^8.0.5",
     "svelte": "^5.56.10",


### PR DESCRIPTION
Only group/task from ostia's bench API is used here, so none of
the 0.2.3 breaking changes (compareDocuments shape, timeSource
flags, CLI exit codes, baselines) apply. Also fixes a comment in
build-index.bench.ts that referenced ostia's old lack of an
in-suite run().