### PR TITLE
perf(optimize-imports): emit source map inline, drop magic-string

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,6 @@
         "carbon-components-svelte-old": "npm:carbon-components-svelte@0.85.0",
         "culls": "^0.2.0",
         "estree-walker": "^2.0.2",
-        "magic-string": "^0.30.17",
         "ostia": "^0.2.4",
         "postcss": "^8.5.28",
         "postcss-discard-empty": "^8.0.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "carbon-components-svelte-old": "npm:carbon-components-svelte@0.85.0",
     "culls": "^0.2.0",
     "estree-walker": "^2.0.2",
-    "magic-string": "^0.30.17",
     "ostia": "^0.2.4",
     "postcss": "^8.5.28",
     "postcss-discard-empty": "^8.0.5",

--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -1,120 +1,320 @@
-import MagicString from "magic-string";
 import type { SveltePreprocessor } from "svelte/types/compiler/preprocess";
 import { getComponents, setComponents } from "../component-index-registry";
 import { CarbonSvelte } from "../constants";
 import { ensureLiveComponentIndex } from "../indexer/live-index";
 
 const NODE_MODULES_REGEX = /node_modules/;
-const COMPONENT_NAME_REGEX = /^[A-Z]/;
-
-type ImportSpecifier = {
-  imported: { name: string };
-  local: { name: string };
-  importKind?: "type" | "value";
-};
-
-type ImportStatement = {
-  start: number;
-  end: number;
-  importKind?: "type" | "value";
-  source: { value: string };
-  specifiers: ImportSpecifier[];
-};
 
 // Import specifiers can't contain a semicolon, so bounding the clause with
 // `[^;]` keeps the lazy match from ever crossing into a later statement,
 // without needing a stateful parser to find each declaration's extent.
 const IMPORT_DECLARATION_REGEX =
   /^([ \t]*)import\s+(type\s+)?(?:([^;]*?)\s+from\s+)?["']([^"']+)["']\s*;?/gm;
-const NAMED_SPECIFIERS_REGEX = /\{([^}]*)\}/;
 const TYPE_SPECIFIER_PREFIX_REGEX = /^type\s+/;
 const AS_ALIAS_REGEX = /\s+as\s+/;
+const WHITESPACE_REGEX = /\s/;
 
-function parseSpecifiers(clause: string | undefined): ImportSpecifier[] {
-  const namedClause = clause && NAMED_SPECIFIERS_REGEX.exec(clause)?.[1];
-  if (!namedClause?.trim()) return [];
+function isWhitespace(code: number): boolean {
+  // ASCII controls/space cover real-world source; anything non-ASCII defers
+  // to the regex so exotic Unicode spaces still trim like `String#trim`.
+  return (
+    code <= 32 ||
+    (code > 127 && WHITESPACE_REGEX.test(String.fromCharCode(code)))
+  );
+}
 
-  return namedClause
-    .split(",")
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .map((entry) => {
-      const isType = TYPE_SPECIFIER_PREFIX_REGEX.test(entry);
-      const [imported, local] = entry
-        .replace(TYPE_SPECIFIER_PREFIX_REGEX, "")
-        .split(AS_ALIAS_REGEX);
-      return {
-        imported: { name: imported.trim() },
-        local: { name: (local ?? imported).trim() },
-        importKind: isType ? "type" : "value",
-      } satisfies ImportSpecifier;
-    });
+type ComponentIndex = ReturnType<typeof getComponents>;
+
+/**
+ * Resolves the direct-path replacement for a named specifier, or `undefined`
+ * when it should stay on the barrel.
+ *
+ * Names missing from the component index: PascalCase gets an optimistic
+ * `src/Name/Name.svelte` path; camelCase stays on the barrel so utilities
+ * don't point at a `.svelte` file that isn't there.
+ */
+function resolvePath(
+  source: string,
+  imported: string,
+  components: ComponentIndex,
+): string | undefined {
+  if (source !== CarbonSvelte.Components) {
+    return `${source}/lib/${imported}.svelte`;
+  }
+
+  // Prefer indexed path (handles .js and other special cases).
+  const path = components[imported]?.path;
+  if (path !== undefined) return path;
+
+  // Not in index: PascalCase gets an optimistic component path;
+  // camelCase stays on the barrel (utility, not a .svelte file).
+  const code = imported.charCodeAt(0);
+  if (code >= 65 && code <= 90) {
+    return `${source}/src/${imported}/${imported}.svelte`;
+  }
+
+  return undefined;
 }
 
 /**
+ * Builds the direct-path replacement for one barrel import statement, or
+ * returns `null` when nothing in it should change.
+ *
  * `optimizeImports` only ever rewrites named specifiers from three known
- * barrel sources (see the `switch` in `transformScript`), so this only needs
- * to recover exactly what `rewriteImport` reads: each statement's source,
- * span, and named specifiers. Default/namespace specifiers are never
- * rewritten, so they're intentionally left out of the parsed shape.
+ * barrel sources, so this only scans the `{ ... }` clause. Default/namespace
+ * specifiers are never rewritten, so they're intentionally left alone.
  */
-function parseImportDeclarations(code: string): ImportStatement[] {
-  const statements: ImportStatement[] = [];
-
-  for (const match of code.matchAll(IMPORT_DECLARATION_REGEX)) {
-    const [full, leadingWhitespace, typeKeyword, clause, source] = match;
-    const start = match.index + leadingWhitespace.length;
-    statements.push({
-      start,
-      end: match.index + full.length,
-      importKind: typeKeyword ? "type" : "value",
-      source: { value: source },
-      specifiers: parseSpecifiers(clause),
-    });
-  }
-
-  return statements;
-}
-
 function rewriteImport(
-  s: MagicString,
-  node: ImportStatement,
-  map: (specifier: ImportSpecifier) => string,
-) {
-  // Type-only statements (`import type { ... }`) never reference a real
-  // `.svelte` file, so leave them entirely untouched.
-  if (node.importKind === "type") return;
+  source: string,
+  clause: string | undefined,
+  components: ComponentIndex,
+): string | null {
+  if (
+    source !== CarbonSvelte.Components &&
+    source !== CarbonSvelte.Icons &&
+    source !== CarbonSvelte.Pictograms
+  ) {
+    return null;
+  }
+  if (!clause) return null;
 
-  const rewritten: string[] = [];
-  const preserved: ImportSpecifier[] = [];
+  const open = clause.indexOf("{");
+  if (open === -1) return null;
+  const close = clause.indexOf("}", open + 1);
+  if (close === -1) return null;
 
-  for (const specifier of node.specifiers) {
-    // Per-specifier type imports (`import { type X, Y }`) stay on the barrel.
-    const fragment = specifier.importKind === "type" ? "" : map(specifier);
-    if (fragment) {
-      rewritten.push(fragment.trimEnd());
+  let rewritten = "";
+  let preserved = "";
+
+  // Walk the comma-separated entries in place: one slice per name instead
+  // of split + trim allocations for every specifier.
+  let index = open + 1;
+  while (index < close) {
+    while (index < close && isWhitespace(clause.charCodeAt(index))) index++;
+    if (index >= close) break;
+
+    let entryEnd = clause.indexOf(",", index);
+    if (entryEnd === -1 || entryEnd > close) entryEnd = close;
+    let end = entryEnd;
+    while (end > index && isWhitespace(clause.charCodeAt(end - 1))) end--;
+
+    let imported: string;
+    let local: string;
+    let isType = false;
+
+    // Bare `Name` (the overwhelmingly common case) has no inner whitespace;
+    // only `type Name` and `Name as Alias` do.
+    let space = index;
+    while (space < end && !isWhitespace(clause.charCodeAt(space))) space++;
+    if (space === end) {
+      imported = local = clause.slice(index, end);
     } else {
-      // Falsy return: keep specifier for barrel re-import below.
-      preserved.push(specifier);
+      let entry = clause.slice(index, end);
+      isType = TYPE_SPECIFIER_PREFIX_REGEX.test(entry);
+      if (isType) entry = entry.replace(TYPE_SPECIFIER_PREFIX_REGEX, "");
+      const [importedPart, localPart] = entry.split(AS_ALIAS_REGEX);
+      imported = importedPart.trim();
+      local = (localPart ?? importedPart).trim();
     }
+
+    // Per-specifier type imports (`import { type X, Y }`) stay on the barrel.
+    const path = isType ? undefined : resolvePath(source, imported, components);
+
+    if (path === undefined) {
+      // Keep specifier for barrel re-import below.
+      if (preserved) preserved += ", ";
+      if (isType) preserved += "type ";
+      preserved += imported === local ? local : `${imported} as ${local}`;
+    } else {
+      if (rewritten) rewritten += "\n";
+      rewritten += `import ${local} from "${path}";`;
+    }
+
+    index = entryEnd + 1;
   }
 
-  if (rewritten.length === 0) return;
+  if (!rewritten) return null;
 
   // Mixed imports: put preserved names back on the barrel next to rewritten paths.
-  if (preserved.length > 0) {
-    const names = preserved.map((specifier) => {
-      const prefix = specifier.importKind === "type" ? "type " : "";
-      return specifier.imported.name === specifier.local.name
-        ? `${prefix}${specifier.local.name}`
-        : `${prefix}${specifier.imported.name} as ${specifier.local.name}`;
-    });
-    rewritten.push(
-      `import { ${names.join(", ")} } from "${node.source.value}";`,
-    );
+  if (preserved) {
+    rewritten += `\nimport { ${preserved} } from "${source}";`;
   }
 
-  s.update(node.start, node.end, rewritten.join("\n"));
+  return rewritten;
+}
+
+const BASE64_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+function encodeVlq(value: number): string {
+  let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
+  let encoded = "";
+  do {
+    let digit = vlq & 31;
+    vlq >>>= 5;
+    if (vlq > 0) digit |= 32;
+    encoded += BASE64_CHARS[digit];
+  } while (vlq > 0);
+  return encoded;
+}
+
+// Inside an untouched run of text, generated and original columns advance in
+// lockstep, so every segment after the first on a line is a delta `d` on both:
+// `,<vlq(d)>A A <vlq(d)>` (source index 0, same source line). Precomputing
+// those for realistic word/punctuation gaps turns the hot path into one
+// string append.
+const SAME_LINE_SEGMENTS = Array.from(
+  { length: 128 },
+  (_, delta) => `,${encodeVlq(delta)}AA${encodeVlq(delta)}`,
+);
+
+function isWordChar(code: number): boolean {
+  return (
+    (code >= 97 && code <= 122) || // a-z
+    (code >= 65 && code <= 90) || // A-Z
+    (code >= 48 && code <= 57) || // 0-9
+    code === 95 // _
+  );
+}
+
+/**
+ * Builds a v3 source map while the transformed code is emitted, tracking the
+ * original cursor as text is copied or replaced so no separate locator pass
+ * over the input is needed.
+ *
+ * Mapping resolution matches magic-string's `hires: "boundary"`: untouched
+ * text gets a segment at the start of every word and at each non-word
+ * character; each line of replacement text maps back to the start of the
+ * statement it replaced.
+ */
+class MappingsBuilder {
+  private mappings = "";
+  // Original cursor (position in the input the next copy/replace consumes).
+  private line = 0;
+  private column = 0;
+  // Generated cursor.
+  private genColumn = 0;
+  private lineHasSegments = false;
+  // Previous segment fields (source map v3 mappings are delta-encoded).
+  private prevGenColumn = 0;
+  private prevLine = 0;
+  private prevColumn = 0;
+
+  /** Copies `text` from the original to the output unchanged. */
+  copy(text: string): void {
+    const length = text.length;
+    if (length === 0) return;
+
+    let inWord = false;
+    let sameLine = false;
+    let mappings = this.mappings;
+    let { column, genColumn } = this;
+
+    for (let i = 0; i < length; i++) {
+      const code = text.charCodeAt(i);
+
+      if (code === 10) {
+        mappings += ";";
+        this.line++;
+        column = 0;
+        genColumn = 0;
+        this.prevGenColumn = 0;
+        this.lineHasSegments = false;
+        inWord = false;
+        sameLine = false;
+        continue;
+      }
+
+      const word = isWordChar(code);
+      if (!word || !inWord) {
+        if (sameLine) {
+          const delta = column - this.prevColumn;
+          mappings +=
+            delta < 128
+              ? SAME_LINE_SEGMENTS[delta]
+              : `,${encodeVlq(delta)}AA${encodeVlq(delta)}`;
+          this.prevGenColumn = genColumn;
+          this.prevColumn = column;
+        } else {
+          this.mappings = mappings;
+          this.column = column;
+          this.genColumn = genColumn;
+          this.addSegment();
+          mappings = this.mappings;
+          sameLine = true;
+        }
+      }
+      inWord = word;
+
+      column++;
+      genColumn++;
+    }
+
+    this.mappings = mappings;
+    this.column = column;
+    this.genColumn = genColumn;
+  }
+
+  /**
+   * Emits `content` in place of `original[start, end)`, mapping every line of
+   * it back to the replaced text's start.
+   */
+  replace(content: string, original: string, start: number, end: number): void {
+    this.addSegment();
+
+    let lineStart = 0;
+    let newline = content.indexOf("\n");
+    while (newline !== -1) {
+      lineStart = newline + 1;
+      // Each further line starts at generated column 0 and maps to the same
+      // original position, so all four deltas are zero. A trailing newline
+      // leaves an empty last line with no segment.
+      this.mappings += lineStart < content.length ? ";AAAA" : ";";
+      newline = content.indexOf("\n", lineStart);
+    }
+
+    if (lineStart === 0) {
+      this.genColumn += content.length;
+    } else {
+      this.genColumn = content.length - lineStart;
+      this.prevGenColumn = 0;
+      this.lineHasSegments = lineStart < content.length;
+    }
+
+    this.skip(original, start, end);
+  }
+
+  /** Advances the original cursor past `original[start, end)`. */
+  private skip(original: string, start: number, end: number): void {
+    let lastNewline = -1;
+    let newline = original.indexOf("\n", start);
+    while (newline !== -1 && newline < end) {
+      this.line++;
+      lastNewline = newline;
+      newline = original.indexOf("\n", newline + 1);
+    }
+    this.column =
+      lastNewline === -1 ? this.column + (end - start) : end - lastNewline - 1;
+  }
+
+  /** Adds a segment mapping the generated cursor to the original cursor. */
+  private addSegment(): void {
+    const { genColumn, line, column } = this;
+    this.mappings +=
+      (this.lineHasSegments ? "," : "") +
+      encodeVlq(genColumn - this.prevGenColumn) +
+      "A" +
+      encodeVlq(line - this.prevLine) +
+      encodeVlq(column - this.prevColumn);
+    this.lineHasSegments = true;
+    this.prevGenColumn = genColumn;
+    this.prevLine = line;
+    this.prevColumn = column;
+  }
+
+  toString(): string {
+    return this.mappings;
+  }
 }
 
 /**
@@ -156,45 +356,59 @@ export type OptimizeImportsOptions = {
 
 function transformScript(raw: string, filename: string) {
   const components = getComponents();
-  const s = new MagicString(raw);
+  let code = "";
+  let mappings: MappingsBuilder | undefined;
+  let lastIndex = 0;
 
-  for (const node of parseImportDeclarations(raw)) {
-    const import_name = node.source.value;
+  IMPORT_DECLARATION_REGEX.lastIndex = 0;
+  let match = IMPORT_DECLARATION_REGEX.exec(raw);
+  while (match !== null) {
+    const index = match.index;
+    // `match[2]` is the `type` keyword: type-only statements
+    // (`import type { ... }`) never reference a real `.svelte` file, so
+    // leave them entirely untouched.
+    const replacement = match[2]
+      ? null
+      : rewriteImport(match[4], match[3], components);
 
-    switch (import_name) {
-      case CarbonSvelte.Components:
-        rewriteImport(s, node, ({ imported, local }) => {
-          // Prefer indexed path (handles .js and other special cases).
-          const import_path = components[imported.name]?.path;
-          if (import_path) {
-            return `import ${local.name} from "${import_path}";`;
-          }
+    if (replacement !== null) {
+      const start = index + match[1].length;
+      const end = index + match[0].length;
+      const unchanged = raw.slice(lastIndex, start);
 
-          // Not in index: PascalCase gets an optimistic component path;
-          // camelCase stays on the barrel (utility, not a .svelte file).
-          const looks_like_component = COMPONENT_NAME_REGEX.test(imported.name);
-          if (looks_like_component) {
-            return `import ${local.name} from "${import_name}/src/${imported.name}/${imported.name}.svelte";`;
-          }
+      mappings ??= new MappingsBuilder();
+      mappings.copy(unchanged);
+      mappings.replace(replacement, raw, start, end);
 
-          return "";
-        });
-        break;
-
-      case CarbonSvelte.Icons:
-      case CarbonSvelte.Pictograms:
-        rewriteImport(s, node, ({ imported, local }) => {
-          return `import ${local.name} from "${import_name}/lib/${imported.name}.svelte";`;
-        });
-        break;
+      code += unchanged + replacement;
+      lastIndex = end;
     }
+
+    match = IMPORT_DECLARATION_REGEX.exec(raw);
   }
 
+  // Nothing rewritten: hand the content back as-is. Svelte treats a missing
+  // map as an identity map, so no need to build one.
+  if (mappings === undefined) return { code: raw };
+
+  const tail = raw.slice(lastIndex);
+  mappings.copy(tail);
+  code += tail;
+
+  // Svelte only offsets a preprocessor's map to the `<script>` tag's position
+  // when `sources` names the file exactly as Svelte does: by basename.
+  const basename = filename.slice(
+    Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\")) + 1,
+  );
+
   return {
-    code: s.toString(),
-    // Edits are whole-statement replacements, so boundary-level mapping
-    // (one segment per edit) is as accurate as char-level and much cheaper.
-    map: s.generateMap({ source: filename, hires: "boundary" }),
+    code,
+    map: {
+      version: 3,
+      sources: [basename],
+      names: [],
+      mappings: mappings.toString(),
+    },
   };
 }
 
@@ -216,7 +430,7 @@ export const optimizeImports: SveltePreprocessor<"script"> = (
       if (NODE_MODULES_REGEX.test(filename)) return;
 
       // Fast path: the only rewritable import sources contain "carbon-".
-      // Skip MagicString + import scanning for the common no-Carbon file.
+      // Skip import scanning for the common no-Carbon file.
       if (!raw.includes("carbon-")) return;
 
       if (options?.experimental?.liveIndex) {


### PR DESCRIPTION
The map builder tracks the original cursor as text is copied or
replaced, so there's no locator pass and no chunk list. Decoded
mappings are identical to magic-string's `hires: "boundary"` output on
every input I compared, and `dist/index.js` drops ~16 KB now that
magic-string isn't bundled.

## Benchmark

`bun run bench:imports`, median on an M2, same machine before/after:

```
small  (2 imports)    3.02 µs  ->  0.47 µs
medium (11 imports)   6.60 µs  ->  1.79 µs
large  (60+ imports)  26.0 µs  ->  9.1 µs
```

## Source map fix

Previously `sources` held the full filename, so Svelte never applied
the `<script>` line offset and a token on line 6 of a component mapped
to line 4. With the basename, `svelte.preprocess` now resolves it to
line 6 of `App.svelte`.
