### PR TITLE
perf(optimize-css): splice unused rules out of the source text

### DIFF
--- a/src/indexer/css-selector-utils.ts
+++ b/src/indexer/css-selector-utils.ts
@@ -1,19 +1,24 @@
-const CARBON_CLASS = /\.bx--[A-Za-z0-9_-]+/g;
-const LEGACY_CARBON_CLASS = /\.bx-(?!-)[A-Za-z0-9_-]+/g;
-// Matches `/[\s>+~]/`'s practical range for selector text: whitespace plus
-// the three combinator symbols. Checked per-character in a hot loop below,
-// so a Set lookup replaces a regex call.
-const COMBINATOR_CHARS = new Set([
-  " ",
-  "\t",
-  "\n",
-  "\r",
-  "\f",
-  "\v",
-  ">",
-  "+",
-  "~",
-]);
+const HYPHEN = 45;
+const OPEN_PAREN = 40;
+const CLOSE_PAREN = 41;
+
+/** `[A-Za-z0-9_-]`: the characters that continue a class token. */
+function isClassTokenChar(code: number): boolean {
+  return (
+    (code >= 97 && code <= 122) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 48 && code <= 57) ||
+    code === HYPHEN ||
+    code === 95
+  );
+}
+
+/**
+ * `/[\s>+~]/`'s practical range for selector text: whitespace plus the three
+ * combinator symbols. Indexed by char code in a hot loop below.
+ */
+const COMBINATOR_CHARS = new Uint8Array(128);
+for (const ch of " \t\n\r\f\v>+~") COMBINATOR_CHARS[ch.charCodeAt(0)] = 1;
 
 /** Split on commas at parenthesis depth 0. */
 export function splitSelectorList(selector: string): string[] {
@@ -58,8 +63,9 @@ function stripNotPseudoClasses(selector: string): string {
     let depth = 1;
     let i = index + 5;
     for (; i < selector.length && depth > 0; i++) {
-      if (selector[i] === "(") depth++;
-      else if (selector[i] === ")") depth--;
+      const code = selector.charCodeAt(i);
+      if (code === OPEN_PAREN) depth++;
+      else if (code === CLOSE_PAREN) depth--;
     }
 
     start = i;
@@ -69,16 +75,51 @@ function stripNotPseudoClasses(selector: string): string {
   return result + selector.slice(start);
 }
 
-/** `normalized` must already be free of `:not(...)` subtrees. */
+/**
+ * `normalized` must already be free of `:not(...)` subtrees.
+ *
+ * Returns every `.bx--*` class token in order, then every legacy `.bx-*`
+ * token rewritten to `.bx--*`, deduplicated by first occurrence. Runs on
+ * every selector in a Carbon stylesheet, so it scans by index instead of
+ * running the two class regexes and merging their matches.
+ */
 export function getCarbonClassesFromNormalized(normalized: string): string[] {
-  if (!normalized.includes(".bx-")) return [];
+  let index = normalized.indexOf(".bx-");
+  if (index === -1) return [];
 
-  const classes = normalized.match(CARBON_CLASS) ?? [];
-  const legacyClasses = (normalized.match(LEGACY_CARBON_CLASS) ?? []).map(
-    (cls) => cls.replace(".bx-", ".bx--"),
-  );
+  const classes: string[] = [];
+  let legacy: string[] | undefined;
+  const length = normalized.length;
 
-  return [...new Set([...classes, ...legacyClasses])];
+  while (index !== -1) {
+    const isCarbon = normalized.charCodeAt(index + 4) === HYPHEN;
+    const tokenStart = isCarbon ? index + 5 : index + 4;
+    let end = tokenStart;
+    while (end < length && isClassTokenChar(normalized.charCodeAt(end))) {
+      end++;
+    }
+
+    if (end > tokenStart) {
+      if (isCarbon) {
+        const cls = normalized.slice(index, end);
+        if (!classes.includes(cls)) classes.push(cls);
+      } else {
+        const cls = `.bx--${normalized.slice(tokenStart, end)}`;
+        legacy ??= [];
+        if (!legacy.includes(cls)) legacy.push(cls);
+      }
+    }
+
+    index = normalized.indexOf(".bx-", end);
+  }
+
+  if (legacy) {
+    for (const cls of legacy) {
+      if (!classes.includes(cls)) classes.push(cls);
+    }
+  }
+
+  return classes;
 }
 
 /** Split a selector branch into ancestor compounds and the subject compound. */
@@ -87,39 +128,40 @@ export function splitSelectorParts(selector: string): {
   subject: string;
 } {
   const normalized = stripNotPseudoClasses(selector);
-  const parts: string[] = [];
+  const length = normalized.length;
+  let ancestors: string[] | undefined;
+  let last: string | undefined;
   let depth = 0;
   let start = 0;
 
-  const pushPart = (end: number) => {
-    const part = normalized.slice(start, end).trim();
-    if (part) parts.push(part);
-  };
+  for (let i = 0; i <= length; i++) {
+    const code = i < length ? normalized.charCodeAt(i) : -1;
 
-  for (let i = 0; i < normalized.length; i++) {
-    const char = normalized[i];
-
-    if (char === "(") {
+    if (code === OPEN_PAREN) {
       depth++;
-    } else if (char === ")") {
-      depth = Math.max(0, depth - 1);
-    } else if (depth === 0 && COMBINATOR_CHARS.has(char)) {
-      pushPart(i);
+    } else if (code === CLOSE_PAREN) {
+      if (depth > 0) depth--;
+    } else if (
+      i === length ||
+      (depth === 0 && code < 128 && COMBINATOR_CHARS[code] === 1)
+    ) {
+      if (i > start) {
+        const part = normalized.slice(start, i).trim();
+        if (part) {
+          if (last !== undefined) {
+            if (ancestors === undefined) ancestors = [last];
+            else ancestors.push(last);
+          }
+          last = part;
+        }
+      }
       start = i + 1;
     }
   }
 
-  pushPart(normalized.length);
-
-  if (parts.length <= 1) {
-    return {
-      ancestors: [],
-      subject: parts[0] ?? normalized,
-    };
+  if (last === undefined) {
+    return { ancestors: [], subject: normalized };
   }
 
-  return {
-    ancestors: parts.slice(0, -1),
-    subject: parts[parts.length - 1],
-  };
+  return { ancestors: ancestors === undefined ? [] : ancestors, subject: last };
 }

--- a/src/plugins/create-optimized-css.ts
+++ b/src/plugins/create-optimized-css.ts
@@ -4,9 +4,14 @@ import postcss from "postcss";
 import discardEmpty from "postcss-discard-empty";
 import { getComponents } from "../component-index-registry";
 import { ALWAYS_ON_CLASSES } from "../constants";
+import {
+  type SpliceOptimizerOptions,
+  spliceOptimizeCss,
+} from "./css-splice-optimizer";
 import type { SafelistEntry } from "./safelist";
 import {
   hasOptimizableCss,
+  isUnusedIbmPlexFontFace,
   optimizeStrictAtRule,
   optimizeStrictRule,
 } from "./strict-css-optimizer";
@@ -207,21 +212,13 @@ function createPostcssPlugins(
             }
           });
 
-          if (!attributes["font-family"].startsWith("IBM Plex")) {
-            return;
-          }
-
-          const is_mono =
-            attributes["font-style"] === "normal" &&
-            attributes["font-family"] === "IBM Plex Mono" &&
-            attributes["font-weight"] === "400";
-
-          const is_sans =
-            attributes["font-style"] === "normal" &&
-            attributes["font-family"] === "IBM Plex Sans" &&
-            ["300", "400", "600"].includes(attributes["font-weight"]);
-
-          if (!(is_sans || is_mono)) {
+          if (
+            isUnusedIbmPlexFontFace(
+              attributes["font-family"],
+              attributes["font-style"],
+              attributes["font-weight"],
+            )
+          ) {
             node.remove();
             report.removed++;
           }
@@ -253,15 +250,41 @@ function toCssString(source: CreateOptimizedCssOptions["source"]): string {
   ).toString();
 }
 
+/**
+ * The PostCSS pipeline: the reference implementation, and the fallback for
+ * stylesheets `spliceOptimizeCss` does not model.
+ */
+export function optimizeCssWithPostcss(
+  input: string,
+  options: SpliceOptimizerOptions,
+  from?: string,
+): OptimizedCssReport {
+  const report = { removed: 0 };
+  const { css } = postcss(
+    createPostcssPlugins(
+      options.allowlist,
+      options.preserveAllIBMFonts,
+      options.preserveFlatpickr,
+      options.safelist,
+      report,
+    ),
+  ).process(input, { from });
+  return { css, removed: report.removed };
+}
+
 export function createCssOptimizer(
   options: Omit<CreateOptimizedCssOptions, "source" | "from">,
 ) {
-  const preserveAllIBMFonts = options.preserveAllIBMFonts === true;
-  const safelist = options.safelist ?? [];
   const { allowlist, preserveFlatpickr } = buildUsage(
     options.ids,
     options.contentClasses,
   );
+  const optimizerOptions: SpliceOptimizerOptions = {
+    allowlist,
+    preserveAllIBMFonts: options.preserveAllIBMFonts === true,
+    preserveFlatpickr,
+    safelist: options.safelist ?? [],
+  };
 
   return {
     run(
@@ -277,17 +300,13 @@ export function createCssOptimizer(
         return { css: input, removed: 0 };
       }
 
-      const report = { removed: 0 };
-      const { css } = postcss(
-        createPostcssPlugins(
-          allowlist,
-          preserveAllIBMFonts,
-          preserveFlatpickr,
-          safelist,
-          report,
-        ),
-      ).process(input, { from });
-      return { css, removed: report.removed };
+      // Compiled Carbon themes have a plain enough shape that the removals
+      // can be spliced straight out of the source text. The scanner bails on
+      // anything it does not model exactly, and PostCSS takes over.
+      return (
+        spliceOptimizeCss(input, optimizerOptions) ??
+        optimizeCssWithPostcss(input, optimizerOptions, from)
+      );
     },
   };
 }

--- a/src/plugins/css-splice-optimizer.ts
+++ b/src/plugins/css-splice-optimizer.ts
@@ -1,0 +1,1058 @@
+import {
+  isFlatpickrKeyframes,
+  isUnusedIbmPlexFontFace,
+  pruneRuleSelector,
+  type StrictCssOptimizerOptions,
+} from "./strict-css-optimizer";
+
+/**
+ * Optimizes a stylesheet by splicing the source text instead of parsing it
+ * into a PostCSS AST and re-serializing. PostCSS is lossless, so for a
+ * stylesheet whose shape this module models exactly (the shape every
+ * compiled Carbon theme has), removing a node or rewriting a selector is a
+ * pure text edit. Anything outside that shape returns `undefined` and the
+ * caller falls back to PostCSS; the scanner never guesses.
+ *
+ * Fidelity is by construction: the tokenizer and statement parser below
+ * mirror `postcss/lib/tokenize` and `postcss/lib/parser` case by case
+ * (including their quirks, e.g. the `url(` lookbehind buffer and
+ * `RE_BAD_BRACKET`), the visitor pass replays PostCSS's dirty-node re-walk,
+ * and the emitter reproduces `postcss/lib/stringifier`'s semicolon rules.
+ * Constructs where PostCSS output is not a plain splice of the input
+ * (comments inside a selector/declaration, empty declarations, free
+ * semicolons, BOMs, `<` escaping, source-map annotations, `@layer`, ...)
+ * bail.
+ */
+
+export type SpliceOptimizerOptions = StrictCssOptimizerOptions & {
+  preserveAllIBMFonts: boolean;
+};
+
+// Char codes
+const TAB = 9;
+const NEWLINE = 10;
+const FEED = 12;
+const CR = 13;
+const SPACE = 32;
+const BANG = 33;
+const DOUBLE_QUOTE = 34;
+const SINGLE_QUOTE = 39;
+const OPEN_PAREN = 40;
+const CLOSE_PAREN = 41;
+const ASTERISK = 42;
+const HYPHEN = 45;
+const SLASH = 47;
+const COLON = 58;
+const SEMICOLON = 59;
+const AT = 64;
+const OPEN_SQUARE = 91;
+const BACKSLASH = 92;
+const CLOSE_SQUARE = 93;
+const UNDERSCORE = 95;
+const OPEN_CURLY = 123;
+const CLOSE_CURLY = 125;
+const BOM = 0xfeff;
+const BOM_REVERSED = 0xfffe;
+
+// Token types
+const T_SPACE = 1;
+const T_WORD = 2;
+const T_STRING = 3;
+const T_AT_WORD = 4;
+const T_OPEN_PAREN = 5;
+const T_CLOSE_PAREN = 6;
+const T_BRACKETS = 7;
+const T_OPEN_SQUARE = 8;
+const T_CLOSE_SQUARE = 9;
+const T_OPEN_CURLY = 10;
+const T_CLOSE_CURLY = 11;
+const T_COLON = 12;
+const T_SEMICOLON = 13;
+const T_COMMENT = 14;
+
+// Node types
+const N_ROOT = 0;
+const N_RULE = 1;
+const N_AT_BLOCK = 2;
+const N_AT_STATEMENT = 3;
+const N_DECL = 4;
+const N_COMMENT = 5;
+
+/** `RE_WORD_END` minus the `/(?=*)` alternative, which needs a lookahead. */
+const WORD_END = new Uint8Array(128);
+for (const ch of "\t\n\f\r !\"#'():;@[\\]{}") WORD_END[ch.charCodeAt(0)] = 1;
+/** `RE_AT_END`. */
+const AT_END = new Uint8Array(128);
+for (const ch of "\t\n\f\r \"#'()/;[\\]{}") AT_END[ch.charCodeAt(0)] = 1;
+/** Character class of `RE_BAD_BRACKET`. */
+const BAD_BRACKET = new Uint8Array(128);
+for (const ch of "\r\n\"'(/\\") BAD_BRACKET[ch.charCodeAt(0)] = 1;
+
+const IMPORTANT_ONLY = /^![\t\n\f\r ]*important$/i;
+
+/** Thrown to abandon the splice path; never escapes `spliceOptimizeCss`. */
+const BAIL = Symbol("bail");
+
+function bail(): never {
+  throw BAIL;
+}
+
+function isWhitespace(code: number): boolean {
+  return (
+    code === SPACE ||
+    code === NEWLINE ||
+    code === TAB ||
+    code === CR ||
+    code === FEED
+  );
+}
+
+function isHexDigit(code: number): boolean {
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 70) ||
+    (code >= 97 && code <= 102)
+  );
+}
+
+/** `.` in `RE_BAD_BRACKET` does not match line terminators. */
+function isLineTerminator(code: number): boolean {
+  return code === NEWLINE || code === CR || code === 0x2028 || code === 0x2029;
+}
+
+class CssNode {
+  type: number;
+  parent: CssNode | null;
+  nodes: CssNode[] | null;
+  /** Offset where `raws.before` starts. */
+  before: number;
+  /** Offset of the first token. */
+  start: number;
+  /**
+   * Exclusive end. Containers: after `}`. Declarations and at-rule
+   * statements: before the `;` (if any). Comments: after `*​/`.
+   */
+  end: number;
+  /** Declaration / at-rule statement ended with `;` in the source. */
+  semi: boolean;
+  /** Declaration whose property starts with `--`. */
+  custom: boolean;
+  /** Rule: selector range. At-rule: params range. Declaration: value range. */
+  a: number;
+  b: number;
+  /** Declaration: property is `[start, propEnd)`. */
+  propEnd: number;
+  /** At-rule name. */
+  name: string;
+  /** Rule: rewritten selector, or `null` when untouched. */
+  selector: string | null;
+  /** Container `raws.semicolon`. */
+  semicolon: boolean;
+  removed: boolean;
+  dirty: boolean;
+
+  constructor(type: number, parent: CssNode | null, before: number) {
+    this.type = type;
+    this.parent = parent;
+    this.nodes =
+      type === N_ROOT || type === N_RULE || type === N_AT_BLOCK ? [] : null;
+    this.before = before;
+    this.start = before;
+    this.end = before;
+    this.semi = false;
+    this.custom = false;
+    this.a = 0;
+    this.b = 0;
+    this.propEnd = 0;
+    this.name = "";
+    this.selector = null;
+    this.semicolon = false;
+    this.removed = false;
+    this.dirty = false;
+  }
+}
+
+/**
+ * Mirror of `postcss/lib/tokenize`, minus token allocation: each call to
+ * `next()` leaves the token in `type` / `start` / `end` (exclusive).
+ */
+class Tokenizer {
+  css: string;
+  length: number;
+  pos: number;
+  type: number;
+  start: number;
+  end: number;
+  /**
+   * PostCSS keeps a stack of every word token and pops it at each `(` to
+   * decide whether the paren is a `url(` opener. Only "was that word `url`"
+   * matters, so the stack is stored as run lengths of non-`url` words:
+   * `leading` before the first `url`, then one count per `url` pushed.
+   */
+  leading: number;
+  runs: number[];
+  lastBadParen: number;
+
+  constructor(css: string) {
+    this.css = css;
+    this.length = css.length;
+    this.pos = 0;
+    this.type = 0;
+    this.start = 0;
+    this.end = 0;
+    this.leading = 0;
+    this.runs = [];
+    this.lastBadParen = -1;
+  }
+
+  private pushWord(start: number, end: number): void {
+    const css = this.css;
+    if (
+      end - start === 3 &&
+      css.charCodeAt(start) === 117 &&
+      css.charCodeAt(start + 1) === 114 &&
+      css.charCodeAt(start + 2) === 108
+    ) {
+      this.runs.push(0);
+    } else if (this.runs.length > 0) {
+      this.runs[this.runs.length - 1]++;
+    } else {
+      this.leading++;
+    }
+  }
+
+  /** `buffer.pop()[1] === 'url'`. */
+  private popWordIsUrl(): boolean {
+    const runs = this.runs;
+    if (runs.length > 0) {
+      const top = runs.length - 1;
+      if (runs[top] > 0) {
+        runs[top]--;
+        return false;
+      }
+      runs.pop();
+      return true;
+    }
+    if (this.leading > 0) this.leading--;
+    return false;
+  }
+
+  next(): boolean {
+    const css = this.css;
+    const length = this.length;
+    const pos = this.pos;
+    if (pos >= length) return false;
+
+    const code = css.charCodeAt(pos);
+    let next: number;
+    this.start = pos;
+
+    switch (code) {
+      case NEWLINE:
+      case SPACE:
+      case TAB:
+      case CR:
+      case FEED: {
+        next = pos;
+        do {
+          next += 1;
+        } while (isWhitespace(css.charCodeAt(next)));
+        this.type = T_SPACE;
+        this.end = next;
+        break;
+      }
+
+      case OPEN_SQUARE:
+        this.type = T_OPEN_SQUARE;
+        this.end = pos + 1;
+        break;
+      case CLOSE_SQUARE:
+        this.type = T_CLOSE_SQUARE;
+        this.end = pos + 1;
+        break;
+      case OPEN_CURLY:
+        this.type = T_OPEN_CURLY;
+        this.end = pos + 1;
+        break;
+      case CLOSE_CURLY:
+        this.type = T_CLOSE_CURLY;
+        this.end = pos + 1;
+        break;
+      case COLON:
+        this.type = T_COLON;
+        this.end = pos + 1;
+        break;
+      case SEMICOLON:
+        this.type = T_SEMICOLON;
+        this.end = pos + 1;
+        break;
+      case CLOSE_PAREN:
+        this.type = T_CLOSE_PAREN;
+        this.end = pos + 1;
+        break;
+
+      case OPEN_PAREN: {
+        const prevIsUrl = this.popWordIsUrl();
+        const n = css.charCodeAt(pos + 1);
+        if (
+          prevIsUrl &&
+          n !== SINGLE_QUOTE &&
+          n !== DOUBLE_QUOTE &&
+          !isWhitespace(n)
+        ) {
+          next = pos;
+          let escaped: boolean;
+          do {
+            escaped = false;
+            next = css.indexOf(")", next + 1);
+            if (next === -1) bail();
+            let escapePos = next;
+            while (css.charCodeAt(escapePos - 1) === BACKSLASH) {
+              escapePos -= 1;
+              escaped = !escaped;
+            }
+          } while (escaped);
+          this.type = T_BRACKETS;
+          this.end = next + 1;
+        } else if (pos <= this.lastBadParen) {
+          this.type = T_OPEN_PAREN;
+          this.end = pos + 1;
+        } else {
+          next = css.indexOf(")", pos + 1);
+          if (next === -1 || this.hasBadBracketChar(pos + 1, next + 1)) {
+            this.lastBadParen = next === -1 ? length : next;
+            this.type = T_OPEN_PAREN;
+            this.end = pos + 1;
+          } else {
+            this.type = T_BRACKETS;
+            this.end = next + 1;
+          }
+        }
+        break;
+      }
+
+      case SINGLE_QUOTE:
+      case DOUBLE_QUOTE: {
+        const quote = code === SINGLE_QUOTE ? "'" : '"';
+        next = pos;
+        let escaped: boolean;
+        do {
+          escaped = false;
+          next = css.indexOf(quote, next + 1);
+          if (next === -1) bail();
+          let escapePos = next;
+          while (css.charCodeAt(escapePos - 1) === BACKSLASH) {
+            escapePos -= 1;
+            escaped = !escaped;
+          }
+        } while (escaped);
+        this.type = T_STRING;
+        this.end = next + 1;
+        break;
+      }
+
+      case AT: {
+        next = pos + 1;
+        while (next < length) {
+          const c = css.charCodeAt(next);
+          if (c < 128 && AT_END[c] === 1) break;
+          next += 1;
+        }
+        this.type = T_AT_WORD;
+        this.end = next;
+        break;
+      }
+
+      case BACKSLASH: {
+        next = pos;
+        let escaping = true;
+        while (css.charCodeAt(next + 1) === BACKSLASH) {
+          next += 1;
+          escaping = !escaping;
+        }
+        const c = css.charCodeAt(next + 1);
+        if (escaping && c !== SLASH && !isWhitespace(c)) {
+          next += 1;
+          if (isHexDigit(css.charCodeAt(next))) {
+            while (isHexDigit(css.charCodeAt(next + 1))) {
+              next += 1;
+            }
+            if (css.charCodeAt(next + 1) === SPACE) {
+              next += 1;
+            }
+          }
+        }
+        // A `word` token that PostCSS does not push onto its lookbehind buffer.
+        this.type = T_WORD;
+        this.end = next + 1;
+        break;
+      }
+
+      default: {
+        if (code === SLASH && css.charCodeAt(pos + 1) === ASTERISK) {
+          next = css.indexOf("*/", pos + 2);
+          if (next === -1) bail();
+          this.type = T_COMMENT;
+          this.end = next + 2;
+        } else {
+          next = pos + 1;
+          while (next < length) {
+            const c = css.charCodeAt(next);
+            if (c < 128 && WORD_END[c] === 1) break;
+            if (c === SLASH && css.charCodeAt(next + 1) === ASTERISK) break;
+            next += 1;
+          }
+          this.type = T_WORD;
+          this.end = next;
+          this.pushWord(pos, next);
+        }
+        break;
+      }
+    }
+
+    this.pos = this.end;
+    return true;
+  }
+
+  /** `RE_BAD_BRACKET.test(css.slice(from - 1, to))`. */
+  private hasBadBracketChar(from: number, to: number): boolean {
+    const css = this.css;
+    for (let i = from; i < to; i++) {
+      const c = css.charCodeAt(i);
+      if (c < 128 && BAD_BRACKET[c] === 1) {
+        if (!isLineTerminator(css.charCodeAt(i - 1))) return true;
+      }
+    }
+    return false;
+  }
+}
+
+/**
+ * Mirror of the structural half of `postcss/lib/parser`. Produces a tree of
+ * `CssNode`s holding source offsets; bails on any input whose PostCSS
+ * serialization would not be a splice of the source.
+ */
+class Parser {
+  css: string;
+  tokenizer: Tokenizer;
+  root: CssNode;
+  current: CssNode;
+  /** Offset where the pending `raws.before` whitespace starts. */
+  spaces: number;
+  /** Parser `semicolon` flag: last statement ended with `;`. */
+  semicolon: boolean;
+  /** Token buffer for one statement: type, start, end per token. */
+  tokTypes: Uint8Array;
+  tokStarts: Int32Array;
+  tokEnds: Int32Array;
+  tokCount: number;
+
+  constructor(css: string) {
+    this.css = css;
+    this.tokenizer = new Tokenizer(css);
+    this.root = new CssNode(N_ROOT, null, 0);
+    this.current = this.root;
+    this.spaces = 0;
+    this.semicolon = false;
+    this.tokTypes = new Uint8Array(64);
+    this.tokStarts = new Int32Array(64);
+    this.tokEnds = new Int32Array(64);
+    this.tokCount = 0;
+  }
+
+  parse(): CssNode {
+    const tokenizer = this.tokenizer;
+    while (tokenizer.next()) {
+      const type = tokenizer.type;
+      if (type === T_SPACE) continue;
+      if (type === T_CLOSE_CURLY) {
+        this.end(tokenizer.end);
+      } else if (type === T_COMMENT) {
+        this.comment();
+      } else if (type === T_AT_WORD) {
+        this.atrule();
+      } else if (type === T_SEMICOLON || type === T_OPEN_CURLY) {
+        // A free semicolon lands in `raws.ownSemicolon` or the next node's
+        // `before`; a bare `{` is a rule with an empty selector that
+        // `postcss-discard-empty` drops. Neither is a plain splice.
+        bail();
+      } else {
+        this.other();
+      }
+    }
+    this.endFile();
+    return this.root;
+  }
+
+  private init(node: CssNode): void {
+    this.current.nodes?.push(node);
+    node.before = this.spaces;
+    if (node.type !== N_COMMENT) this.semicolon = false;
+  }
+
+  private pushToken(): void {
+    const i = this.tokCount;
+    if (i === this.tokTypes.length) {
+      const size = i * 2;
+      const types = new Uint8Array(size);
+      const starts = new Int32Array(size);
+      const ends = new Int32Array(size);
+      types.set(this.tokTypes);
+      starts.set(this.tokStarts);
+      ends.set(this.tokEnds);
+      this.tokTypes = types;
+      this.tokStarts = starts;
+      this.tokEnds = ends;
+    }
+    const t = this.tokenizer;
+    this.tokTypes[i] = t.type;
+    this.tokStarts[i] = t.start;
+    this.tokEnds[i] = t.end;
+    this.tokCount = i + 1;
+  }
+
+  private comment(): void {
+    const t = this.tokenizer;
+    const node = new CssNode(N_COMMENT, this.current, this.spaces);
+    this.init(node);
+    node.start = t.start;
+    node.end = t.end;
+    this.spaces = t.end;
+  }
+
+  private atrule(): void {
+    const t = this.tokenizer;
+    const css = this.css;
+    const name = css.slice(t.start + 1, t.end);
+    if (name === "") bail();
+    // `postcss-discard-empty` has layer-specific rules.
+    if (name === "layer") bail();
+
+    const node = new CssNode(N_AT_BLOCK, this.current, this.spaces);
+    this.init(node);
+    node.start = t.start;
+    node.name = name;
+
+    const brackets: number[] = [];
+    let open = false;
+    let semi = false;
+    let closedByParent = false;
+    let paramsFrom = -1;
+    let paramsTo = -1;
+    let commentInside = false;
+    let pendingComment = false;
+
+    while (t.next()) {
+      const type = t.type;
+      if (type === T_OPEN_PAREN || type === T_OPEN_SQUARE) {
+        brackets.push(type === T_OPEN_PAREN ? T_CLOSE_PAREN : T_CLOSE_SQUARE);
+      } else if (type === T_OPEN_CURLY && brackets.length > 0) {
+        brackets.push(T_CLOSE_CURLY);
+      } else if (type === brackets[brackets.length - 1]) {
+        brackets.pop();
+      }
+
+      if (brackets.length === 0) {
+        if (type === T_SEMICOLON) {
+          semi = true;
+          break;
+        }
+        if (type === T_OPEN_CURLY) {
+          open = true;
+          break;
+        }
+        if (type === T_CLOSE_CURLY) {
+          closedByParent = true;
+          break;
+        }
+      }
+
+      // Params token. Leading and trailing space/comment tokens become
+      // `afterName` / `between`; a comment between two params tokens would
+      // be stripped from `node.params`, which is not modeled.
+      if (type === T_SPACE || type === T_COMMENT) {
+        if (type === T_COMMENT && paramsFrom !== -1) pendingComment = true;
+      } else {
+        if (paramsFrom === -1) paramsFrom = t.start;
+        if (pendingComment) commentInside = true;
+        paramsTo = t.end;
+      }
+    }
+
+    if (commentInside) bail();
+    if (paramsFrom !== -1) {
+      node.a = paramsFrom;
+      node.b = paramsTo;
+    }
+
+    if (open) {
+      this.current = node;
+      this.spaces = t.end;
+      return;
+    }
+
+    node.type = N_AT_STATEMENT;
+    node.nodes = null;
+    // `@foo;` with no params is dropped by `postcss-discard-empty`.
+    if (paramsFrom === -1) bail();
+
+    if (semi) {
+      node.semi = true;
+      node.end = t.start;
+      this.semicolon = true;
+      this.spaces = t.end;
+    } else if (closedByParent) {
+      node.end = t.start;
+      this.spaces = t.start;
+      this.end(t.end);
+    } else {
+      // EOF: trailing whitespace moves to `root.raws.after`.
+      node.end = paramsTo;
+      this.spaces = paramsTo;
+    }
+  }
+
+  private other(): void {
+    const t = this.tokenizer;
+    const css = this.css;
+    this.tokCount = 0;
+
+    const customProperty =
+      t.type === T_WORD &&
+      css.charCodeAt(t.start) === HYPHEN &&
+      css.charCodeAt(t.start + 1) === HYPHEN;
+
+    const brackets: number[] = [];
+    let colon = false;
+    let end = false;
+    let more = true;
+
+    for (;;) {
+      const type = t.type;
+      this.pushToken();
+
+      if (type === T_OPEN_PAREN || type === T_OPEN_SQUARE) {
+        brackets.push(type === T_OPEN_PAREN ? T_CLOSE_PAREN : T_CLOSE_SQUARE);
+      } else if (customProperty && colon && type === T_OPEN_CURLY) {
+        brackets.push(T_CLOSE_CURLY);
+      } else if (brackets.length === 0) {
+        if (type === T_SEMICOLON) {
+          if (colon) {
+            this.decl(customProperty);
+            return;
+          }
+          // Unknown word.
+          bail();
+        } else if (type === T_OPEN_CURLY) {
+          this.rule();
+          return;
+        } else if (type === T_CLOSE_CURLY) {
+          // Push the `}` back and let `parse()` close the block.
+          t.pos = t.start;
+          this.tokCount--;
+          end = true;
+          break;
+        } else if (type === T_COLON) {
+          colon = true;
+        }
+      } else if (type === brackets[brackets.length - 1]) {
+        brackets.pop();
+      }
+
+      more = t.next();
+      if (!more) break;
+    }
+
+    if (!more) end = true;
+    if (brackets.length > 0) bail();
+
+    if (end && colon) {
+      if (!customProperty) {
+        // Trailing space/comment tokens become statement-level.
+        while (this.tokCount > 0) {
+          const last = this.tokTypes[this.tokCount - 1];
+          if (last !== T_SPACE && last !== T_COMMENT) break;
+          this.tokCount--;
+          t.pos = this.tokStarts[this.tokCount];
+        }
+      }
+      this.decl(customProperty);
+    } else {
+      bail();
+    }
+  }
+
+  private rule(): void {
+    const types = this.tokTypes;
+    const ends = this.tokEnds;
+    // Drop the `{`.
+    let count = this.tokCount - 1;
+    const bodyStart = ends[count];
+    while (count > 0) {
+      const last = types[count - 1];
+      if (last !== T_SPACE && last !== T_COMMENT) break;
+      count--;
+    }
+    for (let i = 0; i < count; i++) {
+      // A comment inside the selector is stripped from `node.selector`.
+      if (types[i] === T_COMMENT) bail();
+    }
+
+    const node = new CssNode(N_RULE, this.current, this.spaces);
+    this.init(node);
+    node.start = this.tokStarts[0];
+    node.a = node.start;
+    node.b = ends[count - 1];
+    this.current = node;
+    this.spaces = bodyStart;
+  }
+
+  private decl(customProperty: boolean): void {
+    const types = this.tokTypes;
+    const starts = this.tokStarts;
+    const ends = this.tokEnds;
+    const css = this.css;
+    let count = this.tokCount;
+
+    let semi = false;
+    let semiEnd = 0;
+    if (types[count - 1] === T_SEMICOLON) {
+      semi = true;
+      semiEnd = ends[count - 1];
+      count--;
+    }
+
+    // PostCSS moves leading non-word tokens into `raws.before` and applies
+    // the `*`/`_` hack; neither shape is modeled.
+    if (types[0] !== T_WORD) bail();
+    const first = css.charCodeAt(starts[0]);
+    if (first === UNDERSCORE || first === ASTERISK) bail();
+
+    // Only whitespace may separate the property from its colon; anything
+    // else lands in `raws.between` or throws.
+    let i = 1;
+    let sawColon = false;
+    for (; i < count; i++) {
+      const type = types[i];
+      if (type === T_COLON) {
+        sawColon = true;
+        i++;
+        break;
+      }
+      if (type !== T_SPACE) bail();
+    }
+    if (!sawColon) bail();
+
+    let valueFrom = -1;
+    let valueTo = -1;
+    let hasBang = false;
+    let parens = 0;
+    for (; i < count; i++) {
+      const type = types[i];
+      if (type === T_COMMENT) bail();
+      if (type === T_SPACE) continue;
+      if (valueFrom === -1) valueFrom = starts[i];
+      valueTo = ends[i];
+      if (type === T_OPEN_PAREN) parens++;
+      else if (type === T_CLOSE_PAREN) parens--;
+      else if (type === T_COLON && parens === 0 && !customProperty) {
+        // "Missed semicolon" / "Double colon" errors, or the `progid:` hack.
+        bail();
+      } else if (type === T_WORD && css.charCodeAt(starts[i]) === BANG) {
+        hasBang = true;
+      }
+    }
+
+    if (customProperty) {
+      // Trailing whitespace is part of a custom property's value.
+      valueTo = ends[count - 1];
+    } else if (valueFrom === -1) {
+      // Empty value: dropped by `postcss-discard-empty`.
+      bail();
+    } else if (hasBang) {
+      // `!important` handling rewrites the value; only bail where it matters:
+      // a bare `!important` is an empty value, and `@font-face` descriptors
+      // are compared verbatim.
+      if (IMPORTANT_ONLY.test(css.slice(valueFrom, valueTo))) bail();
+      for (let p: CssNode | null = this.current; p; p = p.parent) {
+        if (p.type === N_AT_BLOCK && p.name === "font-face") bail();
+      }
+    }
+
+    const node = new CssNode(N_DECL, this.current, this.spaces);
+    this.init(node);
+    node.start = starts[0];
+    node.propEnd = ends[0];
+    node.custom = customProperty;
+    node.a = valueFrom === -1 ? valueTo : valueFrom;
+    node.b = valueTo;
+    node.end = ends[count - 1];
+    node.semi = semi;
+    if (semi) {
+      this.semicolon = true;
+      this.spaces = semiEnd;
+    } else {
+      this.spaces = node.end;
+    }
+  }
+
+  private end(closeEnd: number): void {
+    const current = this.current;
+    if (current.parent === null) bail();
+    this.closeContainer(current);
+    current.end = closeEnd;
+    this.current = current.parent;
+    this.spaces = closeEnd;
+  }
+
+  private endFile(): void {
+    if (this.current.parent !== null) bail();
+    this.closeContainer(this.root);
+  }
+
+  private closeContainer(node: CssNode): void {
+    if (node.nodes && node.nodes.length > 0) {
+      node.semicolon = this.semicolon;
+    }
+    this.semicolon = false;
+  }
+}
+
+function markDirty(node: CssNode | null): void {
+  for (let n = node; n; n = n.parent) n.dirty = true;
+}
+
+class Optimizer {
+  css: string;
+  options: SpliceOptimizerOptions;
+  removed: number;
+
+  constructor(css: string, options: SpliceOptimizerOptions) {
+    this.css = css;
+    this.options = options;
+    this.removed = 0;
+  }
+
+  /** Same order as `LazyResult#walkSync`: visitors first, then children. */
+  visit(node: CssNode, all: boolean): void {
+    if (node.type === N_RULE) {
+      this.visitRule(node);
+    } else if (node.type === N_AT_BLOCK || node.type === N_AT_STATEMENT) {
+      this.visitAtRule(node);
+    }
+    if (node.removed) return;
+    const nodes = node.nodes;
+    if (!nodes) return;
+    for (const child of nodes) {
+      if (child.removed) continue;
+      if (all || child.dirty) {
+        child.dirty = false;
+        this.visit(child, all);
+      }
+    }
+  }
+
+  private visitRule(node: CssNode): void {
+    const selector = node.selector ?? this.css.slice(node.a, node.b);
+    const pruned = pruneRuleSelector(selector, this.options);
+    if (!pruned) return;
+    this.removed += pruned.removed;
+    if (pruned.selector === null) {
+      node.removed = true;
+      markDirty(node.parent);
+    } else {
+      node.selector = pruned.selector;
+      markDirty(node);
+    }
+  }
+
+  private visitAtRule(node: CssNode): void {
+    const css = this.css;
+    if (
+      isFlatpickrKeyframes(node.name, css.slice(node.a, node.b), this.options)
+    ) {
+      node.removed = true;
+      markDirty(node.parent);
+      this.removed++;
+      return;
+    }
+
+    if (!this.options.preserveAllIBMFonts && node.name === "font-face") {
+      let family = "";
+      let style = "";
+      let weight = "";
+      const stack: CssNode[] = [];
+      if (node.nodes) {
+        for (let i = node.nodes.length - 1; i >= 0; i--) {
+          stack.push(node.nodes[i]);
+        }
+      }
+      while (stack.length > 0) {
+        const child = stack.pop() as CssNode;
+        if (child.removed) continue;
+        if (child.type === N_DECL) {
+          const prop = css.slice(child.start, child.propEnd);
+          if (prop === "font-family") {
+            family = css.slice(child.a, child.b);
+          } else if (prop === "font-style") {
+            style = css.slice(child.a, child.b);
+          } else if (prop === "font-weight") {
+            weight = css.slice(child.a, child.b);
+          }
+        } else if (child.nodes) {
+          for (let i = child.nodes.length - 1; i >= 0; i--) {
+            stack.push(child.nodes[i]);
+          }
+        }
+      }
+
+      if (isUnusedIbmPlexFontFace(family, style, weight)) {
+        node.removed = true;
+        markDirty(node.parent);
+        this.removed++;
+      }
+    }
+  }
+
+  run(root: CssNode): void {
+    // PostCSS re-walks nodes dirtied by a visitor (rewritten rules and the
+    // parents of removed nodes) until the tree settles. Replay that so the
+    // visitors see the same sequence of calls.
+    this.visit(root, true);
+    while (root.dirty) {
+      root.dirty = false;
+      this.visit(root, false);
+    }
+    discardEmpty(root);
+  }
+}
+
+/** `postcss-discard-empty`, restricted to the cases the parser lets through. */
+function discardEmpty(node: CssNode): void {
+  const nodes = node.nodes;
+  if (!nodes) return;
+  let kept = 0;
+  for (const child of nodes) {
+    if (child.removed) continue;
+    discardEmpty(child);
+    if (!child.removed) kept++;
+  }
+  if (kept === 0 && node.type !== N_ROOT) {
+    node.removed = true;
+  }
+}
+
+class Emitter {
+  css: string;
+  out: string[];
+  cursor: number;
+
+  constructor(css: string) {
+    this.css = css;
+    this.out = [];
+    this.cursor = 0;
+  }
+
+  private flush(to: number): void {
+    if (to > this.cursor) this.out.push(this.css.slice(this.cursor, to));
+    this.cursor = to;
+  }
+
+  emit(root: CssNode): string {
+    this.body(root);
+    this.flush(this.css.length);
+    return this.out.join("");
+  }
+
+  /** Mirror of the stringifier's `pushBody` semicolon rules. */
+  private body(container: CssNode): void {
+    const nodes = container.nodes as CssNode[];
+    let keptCount = 0;
+    let last = -1;
+    for (const node of nodes) {
+      if (node.removed) continue;
+      if (node.type !== N_COMMENT) last = keptCount;
+      keptCount++;
+    }
+
+    // `Root#removeChild` hands a removed first child's `raws.before` to the
+    // node that takes its place, so the first surviving root node keeps the
+    // stylesheet's original leading whitespace.
+    const inherited =
+      container.type === N_ROOT && nodes.length > 1 && nodes[0].removed
+        ? nodes[0]
+        : null;
+
+    let i = 0;
+    for (const node of nodes) {
+      if (node.removed) {
+        this.flush(node.before);
+        this.cursor = node.semi ? node.end + 1 : node.end;
+        continue;
+      }
+
+      if (inherited !== null && i === 0) {
+        this.out.push(this.css.slice(inherited.before, inherited.start));
+        this.cursor = node.start;
+      }
+
+      if (node.type === N_RULE) {
+        if (node.selector !== null) {
+          this.flush(node.a);
+          this.out.push(node.selector);
+          this.cursor = node.b;
+        }
+        this.body(node);
+      } else if (node.type === N_AT_BLOCK) {
+        this.body(node);
+      } else if (node.type === N_DECL || node.type === N_AT_STATEMENT) {
+        let semicolon = i !== last || container.semicolon;
+        if (
+          !semicolon &&
+          i < keptCount - 1 &&
+          (node.type === N_AT_STATEMENT || node.custom)
+        ) {
+          semicolon = true;
+        }
+        if (semicolon !== node.semi) {
+          this.flush(node.end);
+          if (semicolon) {
+            this.out.push(";");
+          } else {
+            this.cursor = node.end + 1;
+          }
+        }
+      }
+      i++;
+    }
+  }
+}
+
+/**
+ * Returns the optimized stylesheet, or `undefined` when the input falls
+ * outside the modeled shape and must go through PostCSS instead. All shape
+ * checks happen before any allowlist/safelist logic runs, so a bail leaves
+ * caller-provided `RegExp` safelist entries untouched.
+ */
+export function spliceOptimizeCss(
+  css: string,
+  options: SpliceOptimizerOptions,
+): { css: string; removed: number } | undefined {
+  const first = css.charCodeAt(0);
+  if (first === BOM || first === BOM_REVERSED) return undefined;
+  // The stringifier escapes `<` in `</style` and `<!--`; a map annotation
+  // makes PostCSS strip it and emit a source map.
+  if (css.includes("<") || css.includes("sourceMappingURL")) return undefined;
+
+  let root: CssNode;
+  try {
+    root = new Parser(css).parse();
+  } catch (error) {
+    if (error === BAIL) return undefined;
+    throw error;
+  }
+
+  const optimizer = new Optimizer(css, options);
+  optimizer.run(root);
+  return { css: new Emitter(css).emit(root), removed: optimizer.removed };
+}

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -1,10 +1,6 @@
 import type { AtRule, Rule } from "postcss";
 import { getComponents } from "../component-index-registry";
-import {
-  ALWAYS_ON_CLASSES,
-  CARBON_PREFIX,
-  CONTEXT_ANCESTORS,
-} from "../constants";
+import { ALWAYS_ON_CLASSES, CONTEXT_ANCESTORS } from "../constants";
 import {
   getCarbonClassesFromNormalized,
   splitSelectorList,
@@ -12,7 +8,6 @@ import {
 } from "../indexer/css-selector-utils";
 import { isSafelisted, type SafelistEntry } from "./safelist";
 
-const LEGACY_CARBON_PREFIX = /bx-(?!-)/;
 const FLATPICKR_CLASS_NAMES = [
   "dayContainer",
   "numInputWrapper",
@@ -173,18 +168,9 @@ function classMatchesAllowlist(name: string, index: AllowlistIndex): boolean {
 function shouldKeepSelector(selector: string, index: AllowlistIndex): boolean {
   const parts = splitSelectorParts(selector);
   const subjectClasses = getCarbonClassesFromNormalized(parts.subject);
-  const ancestorClasses = parts.ancestors.flatMap((part) =>
-    getCarbonClassesFromNormalized(part),
-  );
 
-  if (subjectClasses.length === 0 && ancestorClasses.length === 0) {
-    return true;
-  }
-
-  if (ancestorClasses.length === 0) {
-    return subjectClasses.every((name) => matchesAllowlist(name, index));
-  }
-
+  // Most pruned rules fail on their subject, so ancestor classes are only
+  // extracted once the subject has passed (or has no Carbon class at all).
   if (
     subjectClasses.length > 0 &&
     !subjectClasses.every((name) => matchesAllowlist(name, index))
@@ -192,7 +178,76 @@ function shouldKeepSelector(selector: string, index: AllowlistIndex): boolean {
     return false;
   }
 
+  if (parts.ancestors.length === 0) {
+    return true;
+  }
+
+  const ancestorClasses = parts.ancestors.flatMap((part) =>
+    getCarbonClassesFromNormalized(part),
+  );
+
   return ancestorClasses.every((name) => classMatchesAllowlist(name, index));
+}
+
+export type PrunedSelector = {
+  /** Selectors removed from the list. */
+  removed: number;
+  /** The trimmed selector list, or `null` when the whole rule goes. */
+  selector: string | null;
+};
+
+/**
+ * Decides what strict mode does to a rule's selector list: `undefined` when
+ * nothing changes, otherwise the pruned list (or `null` to drop the rule)
+ * with the number of Carbon selectors removed.
+ */
+export function pruneRuleSelector(
+  selector: string,
+  options: StrictCssOptimizerOptions,
+): PrunedSelector | undefined {
+  const { allowlist, preserveFlatpickr, safelist } = options;
+  const index = getAllowlistIndex(allowlist);
+
+  // `bx-` is either followed by another hyphen (Carbon) or not (legacy), so
+  // one substring check covers both prefixes. A flatpickr match inside any
+  // selectee is also a match on the whole list, so one test on the list rules
+  // it out for every selectee.
+  const hasCarbon = selector.includes("bx-");
+  const hasFlatpickr = FLATPICKR_SELECTOR.test(selector);
+
+  if (!(hasCarbon || hasFlatpickr)) {
+    return undefined;
+  }
+
+  const selectors = splitSelectorList(selector);
+  const keptSelectors = selectors.filter((selectee) => {
+    if (isSafelisted(selectee, safelist)) {
+      return true;
+    }
+
+    if (
+      hasFlatpickr &&
+      !preserveFlatpickr &&
+      FLATPICKR_SELECTOR.test(selectee)
+    ) {
+      return false;
+    }
+
+    return !selectee.includes("bx-") || shouldKeepSelector(selectee, index);
+  });
+
+  if (keptSelectors.length === 0) {
+    return { removed: selectors.length, selector: null };
+  }
+
+  if (keptSelectors.length < selectors.length) {
+    return {
+      removed: selectors.length - keptSelectors.length,
+      selector: keptSelectors.join(", "),
+    };
+  }
+
+  return undefined;
 }
 
 /**
@@ -204,47 +259,29 @@ export function optimizeStrictRule(
   node: Rule,
   options: StrictCssOptimizerOptions,
 ): number {
-  const { allowlist, preserveFlatpickr, safelist } = options;
-  const index = getAllowlistIndex(allowlist);
-  const selector = node.selector;
+  const pruned = pruneRuleSelector(node.selector, options);
+  if (!pruned) return 0;
 
-  if (
-    !(
-      CARBON_PREFIX.test(selector) ||
-      LEGACY_CARBON_PREFIX.test(selector) ||
-      FLATPICKR_SELECTOR.test(selector)
-    )
-  ) {
-    return 0;
-  }
-
-  const selectors = splitSelectorList(selector);
-  const keptSelectors = selectors.filter((selectee) => {
-    if (isSafelisted(selectee, safelist)) {
-      return true;
-    }
-
-    if (FLATPICKR_SELECTOR.test(selectee) && !preserveFlatpickr) {
-      return false;
-    }
-
-    return (
-      !(CARBON_PREFIX.test(selectee) || LEGACY_CARBON_PREFIX.test(selectee)) ||
-      shouldKeepSelector(selectee, index)
-    );
-  });
-
-  if (keptSelectors.length === 0) {
+  if (pruned.selector === null) {
     node.remove();
-    return selectors.length;
+  } else {
+    node.selector = pruned.selector;
   }
 
-  if (keptSelectors.length < selectors.length) {
-    node.selector = keptSelectors.join(", ");
-    return selectors.length - keptSelectors.length;
-  }
+  return pruned.removed;
+}
 
-  return 0;
+/** Whether an at-rule is the flatpickr `@keyframes` block to drop. */
+export function isFlatpickrKeyframes(
+  name: string,
+  params: string,
+  options: Pick<StrictCssOptimizerOptions, "preserveFlatpickr">,
+): boolean {
+  return (
+    !options.preserveFlatpickr &&
+    name === "keyframes" &&
+    FLATPICKR_KEYFRAMES.has(params)
+  );
 }
 
 /**
@@ -254,14 +291,40 @@ export function optimizeStrictAtRule(
   node: AtRule,
   options: Pick<StrictCssOptimizerOptions, "preserveFlatpickr">,
 ): number {
-  if (
-    !options.preserveFlatpickr &&
-    node.name === "keyframes" &&
-    FLATPICKR_KEYFRAMES.has(node.params)
-  ) {
+  if (isFlatpickrKeyframes(node.name, node.params, options)) {
     node.remove();
     return 1;
   }
 
   return 0;
+}
+
+const IBM_PLEX_SANS_WEIGHTS = ["300", "400", "600"];
+
+/**
+ * Whether an IBM Plex `@font-face` rule is one no Carbon Svelte component
+ * uses. Only these faces are kept:
+ * - IBM Plex Sans: weights 300/400/600 in normal style
+ * - IBM Plex Mono: weight 400 in normal style (for code snippets)
+ *
+ * Non-IBM Plex faces are never dropped.
+ */
+export function isUnusedIbmPlexFontFace(
+  family: string,
+  style: string,
+  weight: string,
+): boolean {
+  if (!family.startsWith("IBM Plex")) {
+    return false;
+  }
+
+  const is_mono =
+    style === "normal" && family === "IBM Plex Mono" && weight === "400";
+
+  const is_sans =
+    style === "normal" &&
+    family === "IBM Plex Sans" &&
+    IBM_PLEX_SANS_WEIGHTS.includes(weight);
+
+  return !(is_sans || is_mono);
 }

--- a/tests/css-splice-optimizer.test.ts
+++ b/tests/css-splice-optimizer.test.ts
@@ -1,0 +1,472 @@
+import { getComponents } from "carbon-preprocess-svelte/component-index-registry";
+import { ALWAYS_ON_CLASSES } from "carbon-preprocess-svelte/constants";
+import { optimizeCssWithPostcss } from "carbon-preprocess-svelte/plugins/create-optimized-css";
+import {
+  type SpliceOptimizerOptions,
+  spliceOptimizeCss,
+} from "carbon-preprocess-svelte/plugins/css-splice-optimizer";
+import type { SafelistEntry } from "carbon-preprocess-svelte/plugins/safelist";
+import { resolveCarbonCss } from "./helpers/carbon-css";
+
+/**
+ * The splice optimizer must produce exactly what the PostCSS pipeline
+ * produces for every input it accepts, and must bail (not guess) on every
+ * input it does not model. Both are checked here against the PostCSS
+ * pipeline as the reference: hand-written hostile inputs cover each
+ * construct the scanner special-cases, and a seeded fuzzer covers their
+ * combinations.
+ */
+
+type Scenario = {
+  ids: string[];
+  preserveAllIBMFonts?: boolean;
+  safelist?: SafelistEntry[];
+};
+
+const SCENARIOS: Record<string, Scenario> = {
+  none: { ids: [] },
+  button: { ids: ["Button"] },
+  datepicker: { ids: ["DatePicker", "DatePickerInput"] },
+  fonts: { ids: ["Button"], preserveAllIBMFonts: true },
+  safelist: { ids: ["Accordion"], safelist: [".bx--grid", /^\.bx--btn--/] },
+  // Stateful regexes make the visitor call sequence observable.
+  safelistGlobal: { ids: ["Accordion"], safelist: [/bx--btn/g] },
+};
+
+function toOptions(scenario: Scenario): SpliceOptimizerOptions {
+  const components = getComponents();
+  const allowlist = new Set(ALWAYS_ON_CLASSES);
+  for (const id of scenario.ids) {
+    for (const cls of components[id]?.classes ?? []) allowlist.add(cls);
+  }
+  return {
+    allowlist,
+    preserveAllIBMFonts: scenario.preserveAllIBMFonts === true,
+    preserveFlatpickr: scenario.ids.includes("DatePicker"),
+    // Fresh RegExp instances so `lastIndex` starts equal for both runs.
+    safelist: (scenario.safelist ?? []).map((entry) =>
+      typeof entry === "string" ? entry : new RegExp(entry.source, entry.flags),
+    ),
+  };
+}
+
+type Outcome =
+  | { ok: true; css: string; removed: number }
+  | { ok: false; error: string };
+
+function reference(source: string, scenario: Scenario): Outcome {
+  try {
+    const { css, removed } = optimizeCssWithPostcss(
+      source,
+      toOptions(scenario),
+    );
+    return { ok: true, css, removed };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  }
+}
+
+/** `undefined` when the scanner bailed. */
+function spliced(source: string, scenario: Scenario): Outcome | undefined {
+  const result = spliceOptimizeCss(source, toOptions(scenario));
+  return result && { ok: true, ...result };
+}
+
+function expectParity(source: string, scenario: Scenario): boolean {
+  const actual = spliced(source, scenario);
+  if (actual === undefined) return false;
+  expect(actual).toEqual(reference(source, scenario));
+  return true;
+}
+
+const FF = (family: string, style: string, weight: string) =>
+  `@font-face{font-family:${family};font-style:${style};font-weight:${weight}}`;
+
+/** `[input, splice path expected to accept it]`. */
+const HOSTILE: Record<string, [string, boolean]> = {
+  "single kept": [".bx--btn{color:red}", true],
+  "single removed": [".bx--unused{color:red}", true],
+  "tabs crlf": [
+    ".bx--btn\r\n{\r\n\tcolor:red;\r\n}\r\n.bx--unused{x:y}\r\n",
+    true,
+  ],
+  unicode: ['.bx--btn::before{content:"→ ünïcödé"}.bx--ünused{x:y}', true],
+  "leading ws inherited by new first node": [
+    "\n\n.bx--unused{a:b}\n.bx--btn{c:d}\n",
+    true,
+  ],
+  "leading ws chain": [
+    ".bx--u1{}\n.bx--u2{a:b}\n\n.bx--u3{a:b}\n.bx--btn{a:b}\n.bx--u4{a:b}",
+    true,
+  ],
+  "all removed": ["\n.bx--unused{a:b}\n.bx--unused2{c:d}\n\n", true],
+  "comment statements": [
+    "/* h */\n.bx--btn{/*c*/a:b/*d*/}\n.bx--unused{/*x*/}/* end */",
+    true,
+  ],
+  "comment in selector": [".bx--btn, /*c*/ .bx--unused{a:b}", false],
+  "comment trailing selector": [
+    ".bx--btn /*c*/ {a:b}.bx--unused/*c*/{a:b}",
+    true,
+  ],
+  "comment in decl": [".bx--btn{a:b /*c*/;c:d}", false],
+  "comment after last decl": [".bx--btn{a:b /*c*/}", true],
+  "comment after custom decl": [".bx--btn{--x:1 /*c*/}", false],
+  "comment around params": [
+    "@media /*a*/ screen /*b*/ {.bx--unused{a:b}}",
+    true,
+  ],
+  "comment inside params": [
+    "@media screen /*b*/ and (x){.bx--unused{a:b}}",
+    false,
+  ],
+  "sourcemap annotation": [
+    ".bx--unused{a:b}\n/*# sourceMappingURL=x.css.map */",
+    false,
+  ],
+  "unclosed comment": [".bx--btn{a:b}/*", false],
+  bom: ["﻿.bx--unused{a:b}.bx--btn{c:d}", false],
+  "lt escaping": ['.bx--btn{content:"</style>"}.bx--unused{a:b}', false],
+  "string braces": ['.bx--btn{content:"}{;"}.bx--unused{content:"{"}', true],
+  "string escaped quote": [".bx--btn{content:'a\\'b'}.bx--unused{a:b}", true],
+  "unclosed string": ['.bx--btn{content:"a}', false],
+  "url data": [
+    ".bx--btn{background:url(data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg'%3E)}.bx--unused{a:b}",
+    true,
+  ],
+  "url quoted paren": ['.bx--btn{background:url("x)y")}.bx--unused{a:b}', true],
+  "url unquoted quote": ['.bx--btn{background:url(x"y)}.bx--unused{a:b}', true],
+  "url escaped paren": [
+    ".bx--btn{background:url(a\\)b)}.bx--unused{a:b}",
+    true,
+  ],
+  "url word stack": [
+    ".bx--btn{background:url x () (y'z)}.bx--unused{a:b}",
+    true,
+  ],
+  "url unclosed": [".bx--btn{background:url(a}", false],
+  "bad bracket u2028": ['.bx--btn{a:( "x)}.bx--unused{a:b}', true],
+  "attr brace": ['.bx--btn[b="{"]{a:b}.bx--unused[b;c]{a:b}', true],
+  "not is": [
+    ".bx--btn:not(.bx--unused){a:b}:is(.bx--btn, .bx--unused){a:b}",
+    true,
+  ],
+  "stray close paren": [".bx--btn{a:b)}.bx--unused{a:)b:c}", true],
+  "unclosed bracket": [".bx--btn[a{b:c}", false],
+  media: [
+    "@media (min-width:1px){.bx--unused{a:b}.bx--btn{c:d}}@media x{.bx--unused{a:b}}@media y{}",
+    true,
+  ],
+  "media brace in params": [
+    "@media (a{b){.bx--unused{a:b}}.bx--btn{c:d}",
+    true,
+  ],
+  "font-face keep": [
+    FF("IBM Plex Sans", "normal", "400") + FF("IBM Plex Mono", "normal", "400"),
+    true,
+  ],
+  "font-face drop": [
+    FF("IBM Plex Sans", "italic", "400") + FF("IBM Plex Sans", "normal", "700"),
+    true,
+  ],
+  "font-face other": [
+    FF("Comic Sans", "normal", "700") + FF('"IBM Plex Sans"', "normal", "400"),
+    true,
+  ],
+  "font-face spacing": [
+    "@font-face{font-family: IBM Plex Sans ;font-style:\tnormal;font-weight:\n400 }",
+    true,
+  ],
+  "font-face important": [
+    "@font-face{font-family:IBM Plex Sans;font-style:normal;font-weight:400 !important}",
+    false,
+  ],
+  "font-face upper": [
+    "@FONT-FACE{font-family:IBM Plex Sans;font-style:italic;font-weight:400}",
+    true,
+  ],
+  "font-face statement": ["@font-face;.bx--btn{a:b}", false],
+  "font-face empty": ["@font-face{}.bx--btn{a:b}", true],
+  "font-face nested": [
+    "@font-face{font-family:IBM Plex Sans;font-style:normal;font-weight:400;.bx--unused{a:b}}",
+    true,
+  ],
+  "font-face duplicates": [
+    "@font-face{font-family:IBM Plex Sans;font-weight:400;font-style:italic;font-style:normal}",
+    true,
+  ],
+  "font-face star hack": [
+    "@font-face{*font-family:IBM Plex Sans;font-style:normal;font-weight:700}",
+    false,
+  ],
+  keyframes: [
+    "@keyframes fpFadeInDown{from{opacity:0}to{opacity:1}}@keyframes  fpFadeInDown  {}@-webkit-keyframes fpFadeInDown{}",
+    true,
+  ],
+  "keyframes comment": [
+    "@keyframes fpFadeInDown/*x*/{from{opacity:0}}@keyframes/*x*/fpFadeInDown{}",
+    true,
+  ],
+  "keyframes statement": [
+    "@keyframes fpFadeInDown;.bx--btn{@keyframes fpFadeInDown;a:b}",
+    true,
+  ],
+  "keyframes statement last": [".bx--btn{@keyframes fpFadeInDown}", true],
+  "charset import": [
+    '@charset "utf-8";@import url(x.css);.bx--unused{a:b}',
+    true,
+  ],
+  "import eof": [".bx--unused{a:b}@import 'x'  \n", true],
+  layer: ["@layer a{.bx--unused{a:b}}", false],
+  "at empty statement": ["@foo;.bx--btn{a:b}", false],
+  "at unnamed": ["@{}.bx--btn{a:b}", false],
+  "at last child no semi": [".bx--btn{@x y }.bx--unused{@x y}", true],
+  "decl forms": [
+    ".bx--btn{color:red}.bx--a{color:red;}.bx--b{color:red ; }",
+    true,
+  ],
+  "decl empty": [".bx--btn{color:;a:b}", false],
+  "decl empty ws": [".bx--btn{a:b;color: }", false],
+  "decl important": [
+    ".bx--btn{color:red!important;a:red !IMPORTANT ;b:x ! y important}",
+    true,
+  ],
+  "decl important only": [".bx--btn{color:!important;a:b}", false],
+  "custom property": [".bx--btn{--x:{a:b};--y:;--z: ;--w:a:b;c:d}", true],
+  "custom no colon": [".bx--btn{--x{a:b}}", true],
+  "ie hacks": [".bx--btn{*zoom:1}", false],
+  "missed semicolon": [".bx--btn{b:c:d}", false],
+  progid: [".bx--btn{filter:progid:DX(a)}", false],
+  "square colon": [".bx--btn{b:[c:d]}", false],
+  "colon in url string paren": ['.bx--btn{a:url(c:d);b:"c:d";c:(d:e)}', true],
+  "unknown word": [".bx--btn{b}", false],
+  "root decl": ["color:red;.bx--unused{a:b}x:y", true],
+  "free semicolons": [".bx--btn{b:c;;}", false],
+  "own semicolon": [".bx--unused{};.bx--btn{}", false],
+  "nesting removed child": [
+    ".bx--btn{.bx--unused{x:y}}.bx--unused{.bx--btn{x:y}}",
+    true,
+  ],
+  "nesting semicolon dropped": [".bx--btn{b:c;.bx--unused{x:y}}", true],
+  "nesting semicolon kept": [
+    ".bx--btn{--x:1;/*k*/.bx--unused{x:y}}.bx--a{b:1;/*k*/.bx--unused{x:y}}",
+    true,
+  ],
+  "nesting decl after": [
+    ".bx--btn{.bx--unused{x:y} b:c}.bx--a{@media x{.bx--unused{a:b}}c:d}",
+    true,
+  ],
+  "nesting all removed": [".bx--btn{.bx--unused{.bx--unused2{c:d}}}", true],
+  "comma lists": [
+    ".bx--btn,.bx--unused{a:b}.bx--unused,\n.bx--btn\n{a:b}.bx--btn , .bx--unused , button{a:b}",
+    true,
+  ],
+  "comma edges": [
+    ".bx--btn,{a:b},.bx--btn{a:b}.bx--btn,,.bx--unused{a:b}",
+    true,
+  ],
+  "selector whitespace": [
+    ".bx--btn  \t{a:b}.bx--unused \n {a:b}.bx--btn\v.bx--unused{a:b}.bx--btn {a:b}",
+    true,
+  ],
+  "selector escapes": [
+    ".bx--btn\\:hover{a:b}.bx--unused\\{{a:b}.\\31 0.bx--unused{a:b}.bx--btn\\\\{a:b}",
+    true,
+  ],
+  "backslash eof": [".bx--btn{a:b}\\", false],
+  legacy: [".bx-btn{a:b}.bx-unused{a:b}", true],
+  flatpickr: [".flatpickr-calendar{a:b}.numInputWrapper:hover{a:b}", true],
+  "context ancestors": [
+    ".bx--body{a:b}.bx--body--with-modal-open .bx--tooltip{a:b}",
+    true,
+  ],
+  "close at root": [".bx--btn{a:b}}", false],
+  "unclosed block": [".bx--btn{a:b", false],
+  "empty selector rule": ["{}.bx--btn{a:b}", false],
+  "empty rules": [".bx--btn{}.bx--unused{}a{}", true],
+};
+
+describe("css-splice-optimizer", () => {
+  for (const [name, [source, accepted]] of Object.entries(HOSTILE)) {
+    test(name, () => {
+      for (const scenario of Object.values(SCENARIOS)) {
+        expect(expectParity(source, scenario)).toBe(accepted);
+      }
+    });
+  }
+
+  test("Carbon theme", () => {
+    const source = resolveCarbonCss("white");
+    for (const scenario of Object.values(SCENARIOS)) {
+      expect(expectParity(source, scenario)).toBe(true);
+    }
+  });
+
+  test("fuzz", () => {
+    let seed = 12345;
+    const rnd = () => {
+      seed = (seed * 1664525 + 1013904223) >>> 0;
+      return seed / 0x100000000;
+    };
+    const pick = <T>(items: T[]) => items[Math.floor(rnd() * items.length)];
+    const chance = (p: number) => rnd() < p;
+
+    const WS = ["", "", " ", "\n", "\r\n", "\t", "\f", " \n "];
+    const COMMENTS = ["/*c*/", "/**/", "/* IBM Plex */"];
+    const SELECTORS = [
+      ".bx--btn",
+      ".bx--btn--primary",
+      ".bx--unused",
+      ".bx--accordion__item",
+      ".bx--body",
+      ".bx--body--with-modal-open .bx--tooltip",
+      ".bx--header__global .bx--btn",
+      ".bx-btn",
+      ".bx-unused",
+      ".flatpickr-calendar",
+      ".numInputWrapper:hover",
+      "button",
+      "*",
+      ":root",
+      "::before",
+      "a>b",
+      "a+b",
+      '[data-x="{"]',
+      ".bx--btn:not(.bx--unused)",
+      ":is(.bx--btn, .bx--unused)",
+      ".bx--btn\\:hover",
+      ".\\31 0.bx--btn",
+      ".bx--grid",
+      "button.bx--btn.bx--btn--primary",
+      ".bx--skeleton",
+      "from",
+      "to",
+      ".bx--btn[data-x=url(a'b)]",
+      ".bx--btn ",
+      "#id.bx--unused",
+    ];
+    const PROPS = [
+      "color",
+      "font-family",
+      "font-style",
+      "font-weight",
+      "--x",
+      "src",
+      "content",
+      "*zoom",
+    ];
+    const VALUES = [
+      "red",
+      "#fff",
+      "IBM Plex Sans",
+      "IBM Plex Mono",
+      "normal",
+      "italic",
+      "400",
+      "700",
+      "'IBM Plex Sans'",
+      "url(x.png)",
+      "url(data:image/svg+xml;charset=utf8,%3Csvg%3E)",
+      'url("x)y")',
+      'url(x"y)',
+      "url( x)",
+      '"}{;"',
+      "calc((1px + 2px) * 3)",
+      "(a:b)",
+      "[c:d]",
+      "a:b",
+      "",
+      " ",
+      "!important",
+      "red!important",
+      "red !important ",
+      "x ! y important",
+      "b)",
+      ")c:d",
+      "@b",
+      "x /*c*/",
+      "{a:b}",
+      "IBM Plex Sans ",
+    ];
+    const AT_NAMES = [
+      "media",
+      "supports",
+      "font-face",
+      "keyframes",
+      "layer",
+      "import",
+      "foo",
+      "",
+    ];
+    const AT_PARAMS = [
+      "",
+      " (min-width:1px)",
+      " screen",
+      " fpFadeInDown",
+      " 'x'",
+      " x /*c*/",
+      " a /*c*/ b",
+      " (a{b)",
+    ];
+
+    const comment = () => (chance(0.06) ? pick(COMMENTS) : "");
+    const decl = () =>
+      `${comment()}${pick(WS)}${pick(PROPS)}${pick(WS)}:${pick(WS)}${pick(VALUES)}${chance(0.08) ? comment() : ""}`;
+    const body = (depth: number): string => {
+      const parts: string[] = [];
+      const n = Math.floor(rnd() * 4);
+      for (let i = 0; i < n; i++) {
+        const r = rnd();
+        if (depth > 3 || r < 0.55) {
+          parts.push(decl());
+          if (chance(0.85) || i < n - 1) parts.push(";");
+          if (chance(0.03)) parts.push(";");
+        } else if (r < 0.85) {
+          parts.push(rule(depth));
+        } else {
+          parts.push(atrule(depth));
+        }
+        if (chance(0.05)) parts.push(pick(COMMENTS));
+      }
+      return parts.join("");
+    };
+    const rule = (depth: number): string => {
+      let sel = pick(SELECTORS);
+      if (chance(0.3)) sel += `,${pick(WS)}${pick(SELECTORS)}`;
+      if (chance(0.05)) sel += ",";
+      if (chance(0.05)) sel = `${sel} ${pick(COMMENTS)} ${pick(SELECTORS)}`;
+      return `${comment()}${pick(WS)}${sel}${pick(WS)}${chance(0.05) ? pick(COMMENTS) : ""}{${body(depth + 1)}${pick(WS)}}${chance(0.03) ? ";" : ""}`;
+    };
+    const atrule = (depth: number): string => {
+      const head = `${comment()}${pick(WS)}@${pick(AT_NAMES)}${pick(AT_PARAMS)}${pick(WS)}`;
+      if (chance(0.25)) return `${head};`;
+      if (chance(0.03)) return head;
+      return `${head}{${body(depth + 1)}${pick(WS)}}`;
+    };
+    const sheet = (): string => {
+      const parts: string[] = [];
+      const n = 1 + Math.floor(rnd() * 6);
+      for (let i = 0; i < n; i++) {
+        const r = rnd();
+        if (r < 0.65) parts.push(rule(0));
+        else if (r < 0.9) parts.push(atrule(0));
+        else if (r < 0.95) parts.push(`${decl()}${chance(0.7) ? ";" : ""}`);
+        else parts.push(pick(COMMENTS));
+        if (chance(0.03)) parts.push(";");
+        if (chance(0.02)) parts.push("}");
+      }
+      let css = parts.join(pick(WS)) + pick(WS);
+      if (chance(0.02)) css = `﻿${css}`;
+      if (chance(0.02)) css = css.slice(0, Math.floor(rnd() * css.length));
+      return css;
+    };
+
+    const scenarios = Object.values(SCENARIOS);
+    let accepted = 0;
+    for (let i = 0; i < 2000; i++) {
+      if (expectParity(sheet(), pick(scenarios))) accepted++;
+    }
+    // Sanity check that the fuzzer exercises the splice path, not just bails.
+    expect(accepted).toBeGreaterThan(100);
+  });
+});


### PR DESCRIPTION
Compiled Carbon themes have a plain enough shape that pruning is a text
splice, so `optimizeCssWithReport` now scans the stylesheet with a
purpose-built tokenizer that mirrors PostCSS's and edits the source
directly. Anything the scanner doesn't model exactly (comments inside
selectors or declarations, empty declarations, free semicolons,
`@layer`, BOMs, syntax errors) bails to the unchanged PostCSS pipeline,
so output stays byte-identical. The selector helpers in
`css-selector-utils.ts` also drop their regex matching and per-char
string lookups.

## Benchmark

`bun run bench:css` on an M2, medians of two runs each at load ~2:

```
scenario                                  before    after
single component (Button)                 31.2 ms   8.4 ms
small bundle (DataTable+Toolbar+...)      30.0 ms   8.4 ms
large bundle (UIShell)                    29.9 ms   8.2 ms
```

Parity was checked against the origin/main implementation over every
Carbon theme, the fixtures, 217 hostile inputs and ~110k fuzzed sheets
across 11 option scenarios; `tests/css-splice-optimizer.test.ts` keeps
that as a differential test against the PostCSS path.
