### PR TITLE
feat(plugin): add Rspack support to `OptimizeCssPlugin`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 `carbon-preprocess-svelte` ships Svelte preprocessors and build plugins that make [Carbon Design System](https://github.com/carbon-design-system/carbon-components-svelte) apps smaller and faster. Two separate problems:
 
 - **`optimizeImports`**, a Svelte _script_ preprocessor that rewrites barrel imports (`import { Button } from "carbon-components-svelte"`) into direct path imports (`import Button from "carbon-components-svelte/src/Button/Button.svelte"`) so bundlers tree-shake and HMR stays fast.
-- **`optimizeCss` / `OptimizeCssPlugin`**, build plugins (Vite/Rollup and Webpack) that strip unused Carbon CSS rules from production output.
+- **`optimizeCss` / `OptimizeCssPlugin`**, build plugins (Vite/Rollup and Webpack/Rspack) that strip unused Carbon CSS rules from production output.
 
 Option shapes, usage per bundler, and what each export does are in [README.md](README.md). That file is the source of truth for what the package supports. This file is how the code is built and changed.
 
@@ -53,14 +53,14 @@ bun install
 | `bun run lint:fix` | `biome check --write --unsafe .` (lint + format + organize imports). |
 | `bun run upgrade-examples` | `bun update` inside each `examples/*` project. |
 
-Scope test and lint runs to what you touched (`bun test optimize-imports`, `bunx biome check --write src/plugins`). The full e2e suite is slow because it builds six real apps.
+Scope test and lint runs to what you touched (`bun test optimize-imports`, `bunx biome check --write src/plugins`). The full e2e suite is slow because it builds seven real apps.
 
 ## How it works
 
 The package has two entry points, exported from [`src/index.ts`](src/index.ts):
 
 ```ts
-export { default as OptimizeCssPlugin } from "./plugins/OptimizeCssPlugin"; // Webpack
+export { default as OptimizeCssPlugin } from "./plugins/OptimizeCssPlugin"; // Webpack/Rspack
 export { optimizeCss } from "./plugins/optimize-css";                       // Vite/Rollup
 export { optimizeImports } from "./preprocessors/optimize-imports";         // Svelte preprocessor
 ```
@@ -114,12 +114,12 @@ Set `DEBUG_INDEX=1` to print per-stage timings.
 - Carbon component names resolve through the index `path`. Names missing from the index get an _optimistic_ `src/Name/Name.svelte` path **only if PascalCase**. camelCase utilities stay on the barrel so we never point at a `.svelte` file that is not there. Icons and pictograms map to `lib/Name.svelte`.
 - **Type imports stay on the barrel.** `import type { … }` statements are left alone. In `import { type X, Y }`, `X` stays on the barrel and only `Y` is rewritten. Recent fixes ([#138](https://github.com/carbon-design-system/carbon-preprocess-svelte/pull/138), [#133](https://github.com/carbon-design-system/carbon-preprocess-svelte/pull/133)) live here. Add a fixture in [`tests/optimize-imports.test.ts`](tests/optimize-imports.test.ts) for any import-shape change.
 
-### `optimizeCss` (Vite/Rollup) and `OptimizeCssPlugin` (Webpack)
+### `optimizeCss` (Vite/Rollup) and `OptimizeCssPlugin` (Webpack/Rspack)
 
 Both plugins do the same job through different bundler hooks, then call the same optimizer.
 
 - [`src/plugins/optimize-css.ts`](src/plugins/optimize-css.ts) is the Vite plugin (`apply: "build"`, `enforce: "post"`). It collects Carbon component ids in the `transform` hook (it transforms nothing, just records ids), then rewrites CSS assets in `generateBundle` by mutating `file.source` in place. Synchronous PostCSS.
-- [`src/plugins/OptimizeCssPlugin.ts`](src/plugins/OptimizeCssPlugin.ts) is the Webpack plugin, production-only. It collects ids from `NormalModule` `beforeSnapshot` `fileDependencies`, processes CSS assets at `PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE` (before minification). Async PostCSS, all assets in parallel via `Promise.all`.
+- [`src/plugins/OptimizeCssPlugin.ts`](src/plugins/OptimizeCssPlugin.ts) is the Webpack plugin, production-only. It collects ids by reading each module's `resource` in the `finishModules` hook (fires once the whole module graph has resolved, so every Carbon Svelte component already exists as its own module), then processes CSS assets at `PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE` (before minification). Async PostCSS, all assets in parallel via `Promise.all`. It is typed against a minimal structural subset of the `Compiler`/`Compilation` API (not imported from the `webpack` package) so the same plugin instance also works unchanged with Rspack, which implements that same `compiler.webpack` namespace for plugin compatibility but does not implement webpack's `NormalModule.getCompilationHooks().beforeSnapshot` hook that an earlier version of this plugin relied on.
 
 The shared core is [`src/plugins/create-optimized-css.ts`](src/plugins/create-optimized-css.ts). It builds an **allowlist** of `.bx--*` classes from the bundled components' index entries, plus `ALWAYS_ON_CLASSES` and any `content`-scanned tokens, then runs a PostCSS pipeline (the Carbon rule/at-rule visitor + `postcss-discard-empty`). It exposes sync (`optimizeCssWithReport`) and async (`…Async`) variants because Vite and Webpack differ. Keep the two in lockstep when you change behavior. The `report.removed` count suppresses the size-diff log when nothing was pruned ([#131](https://github.com/carbon-design-system/carbon-preprocess-svelte/pull/131)).
 
@@ -180,12 +180,13 @@ Shared helpers (`buildAllowlist`, `matchesAllowlist`, `shouldKeepStrictSelector`
 
 ### End-to-end tests
 
-[`tests/test-e2e.ts`](tests/test-e2e.ts) (`bun run test:e2e`) builds the package, `bun link`s it into each project under [`examples/`](examples), builds every example, parses the `printDiff` output, and compares CSS reduction to [`tests/__snapshots__/e2e.json`](tests/__snapshots__/e2e.json) within 0.01 tolerance. Unit tests will not catch a plugin that silently no-ops inside a real Vite or Webpack build. This suite will.
+[`tests/test-e2e.ts`](tests/test-e2e.ts) (`bun run test:e2e`) builds the package, `bun link`s it into each project under [`examples/`](examples), builds every example, parses the `printDiff` output, and compares CSS reduction to [`tests/__snapshots__/e2e.json`](tests/__snapshots__/e2e.json) within 0.01 tolerance. Unit tests will not catch a plugin that silently no-ops inside a real Vite, Webpack, or Rspack build. This suite will — it's how the `finishModules`/`resource` rewrite of `OptimizeCssPlugin` was validated against real Webpack and Rspack builds, since the unit test mock alone could not have caught the timing bug where `buildInfo.fileDependencies` isn't populated yet at `finishModules`.
 
 The examples are real downstream consumers, each linking the package via `"carbon-preprocess-svelte": "link:carbon-preprocess-svelte"`:
 
 - `examples/rollup`, `examples/vite`, `examples/vite@svelte-5`, `examples/sveltekit`: Vite/Rollup plugin path
 - `examples/webpack`, `examples/webpack@svelte-5`: Webpack plugin path
+- `examples/rspack`: Rspack plugin path, using the same `OptimizeCssPlugin` export as Webpack
 
 Other Svelte frameworks (Astro, Routify, …) run Vite under the hood, so the Vite examples cover them. When you change output shape or reduction behavior, update snapshots and read the diff:
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bun add -D carbon-preprocess-svelte
 
 - [**optimizeImports**](#optimizeimports): Svelte preprocessor that rewrites Carbon Svelte imports to their source path in the `script` block, making development compile times dramatically faster.
 - [**optimizeCss**](#optimizecss): Vite/Rollup plugin that removes unused Carbon styles, resulting in smaller CSS bundles.
-- [**OptimizeCssPlugin**](#optimizecssplugin): The corresponding `optimizeCss` plugin for Webpack that removes unused Carbon styles.
+- [**OptimizeCssPlugin**](#optimizecssplugin): The corresponding `optimizeCss` plugin for Webpack and Rspack that removes unused Carbon styles.
 
 ### `optimizeImports`
 
@@ -132,6 +132,33 @@ This code is abridged; see [examples/webpack](examples/webpack) for a full set-u
 
 ```js
 // webpack.config.mjs
+import { optimizeImports } from "carbon-preprocess-svelte";
+
+export default {
+  module: {
+    rules: [
+      {
+        test: /\.svelte$/,
+        use: {
+          loader: "svelte-loader",
+          options: {
+            hotReload: !PROD,
+            preprocess: [optimizeImports()],
+            compilerOptions: { dev: !PROD },
+          },
+        },
+      },
+    ],
+  },
+};
+```
+
+#### Rspack
+
+[Rspack](https://rspack.rs) implements webpack's plugin and loader APIs, so the set-up is the same as [Webpack](#webpack) above (`svelte-loader` works unchanged). This code is abridged; see [examples/rspack](examples/rspack) for a full set-up.
+
+```js
+// rspack.config.mjs
 import { optimizeImports } from "carbon-preprocess-svelte";
 
 export default {
@@ -354,12 +381,12 @@ optimizeCss({
 
 ### `OptimizeCssPlugin`
 
-For Webpack users, `OptimizeCssPlugin` is a drop-in replacement for `optimizeCss`. The plugin API is identical to that of `optimizeCss`. Similarly, the plugin only runs in production mode.
+For Webpack and [Rspack](https://rspack.rs) users, `OptimizeCssPlugin` is a drop-in replacement for `optimizeCss`. The plugin API is identical to that of `optimizeCss`. Similarly, the plugin only runs in production mode. The same `OptimizeCssPlugin` instance works unchanged with both bundlers since Rspack implements webpack's plugin API.
 
-This code is abridged; see [examples/webpack](examples/webpack) or [examples/webpack@svelte-5](examples/webpack@svelte-5) for a full set-up.
+This code is abridged; see [examples/webpack](examples/webpack), [examples/webpack@svelte-5](examples/webpack@svelte-5), or [examples/rspack](examples/rspack) for a full set-up.
 
 ```js
-// webpack.config.mjs
+// webpack.config.mjs (or rspack.config.mjs)
 import { OptimizeCssPlugin } from "carbon-preprocess-svelte";
 
 export default {

--- a/examples/rspack/.gitignore
+++ b/examples/rspack/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+public

--- a/examples/rspack/README.md
+++ b/examples/rspack/README.md
@@ -1,0 +1,37 @@
+# rspack
+
+> Used for end-to-end testing and development purposes.
+
+Identical to the `webpack@svelte-5` example, but using [Rspack](https://rspack.rs) instead of webpack. `OptimizeCssPlugin` works unchanged since Rspack implements webpack's plugin API.
+
+## Quick Start
+
+```sh
+# First, build the library locally
+bun run build
+
+# Create a local link to the library
+bun link
+
+# When developing, rebuild the library when making changes
+bun run build -w
+```
+
+In this folder, you can run the following commands:
+
+```sh
+# Install dependencies
+bun i
+```
+
+Run the app in development mode. This should only apply the `optimizeImports` preprocessor.
+
+```sh
+bun run dev
+```
+
+Build the app for production. This should run both the `optimizeImports` and `optimizeCss` preprocessors.
+
+```sh
+bun run build
+```

--- a/examples/rspack/bun.lock
+++ b/examples/rspack/bun.lock
@@ -1,0 +1,165 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "devDependencies": {
+        "@rspack/cli": "latest",
+        "@rspack/core": "latest",
+        "@rspack/dev-server": "latest",
+        "carbon-components-svelte": "latest",
+        "carbon-preprocess-svelte": "link:carbon-preprocess-svelte",
+        "css-loader": "latest",
+        "svelte": "^5.57.0",
+        "svelte-loader": "latest",
+        "svelte-preprocess": "latest",
+        "typescript": "^6.0.3",
+      },
+    },
+  },
+  "packages": {
+    "@emnapi/core": ["@emnapi/core@1.11.3", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.3", "tslib": "^2.4.0" } }, "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g=="],
+
+    "@ibm/telemetry-js": ["@ibm/telemetry-js@1.11.0", "", { "bin": { "ibmtelemetry": "dist/collect.js" } }, "sha512-RO/9j+URJnSfseWg9ZkEX9p+a3Ousd33DBU7rOafoZB08RqdzxFVYJ2/iM50dkBuD0o7WX7GYt1sLbNgCoE+pA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.6.0", "", {}, "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@rspack/binding": ["@rspack/binding@2.2.3", "", { "optionalDependencies": { "@rspack/binding-darwin-arm64": "2.2.3", "@rspack/binding-darwin-x64": "2.2.3", "@rspack/binding-linux-arm64-gnu": "2.2.3", "@rspack/binding-linux-arm64-musl": "2.2.3", "@rspack/binding-linux-ppc64-gnu": "2.2.3", "@rspack/binding-linux-riscv64-gnu": "2.2.3", "@rspack/binding-linux-riscv64-musl": "2.2.3", "@rspack/binding-linux-s390x-gnu": "2.2.3", "@rspack/binding-linux-x64-gnu": "2.2.3", "@rspack/binding-linux-x64-musl": "2.2.3", "@rspack/binding-wasm32-wasi": "2.2.3", "@rspack/binding-win32-arm64-msvc": "2.2.3", "@rspack/binding-win32-ia32-msvc": "2.2.3", "@rspack/binding-win32-x64-msvc": "2.2.3" } }, "sha512-532+T5N6yIdukChiL85H4NFN2vn9oi8wlLa1ByPNtpNYriE9s24fUhn0RiK7w/xACqnNpYmXCqLYCvjOzyCy+w=="],
+
+    "@rspack/binding-darwin-arm64": ["@rspack/binding-darwin-arm64@2.2.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MGLx4lMTY6XEtJi55S+fk83+683GeUDuoqzjixbq6ehHdr/l6nGiHhgvMtV5DYt9sCytUDzyrCkcJ0AWqJxnTA=="],
+
+    "@rspack/binding-darwin-x64": ["@rspack/binding-darwin-x64@2.2.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-5B/c1YTYEz9m7TyqtGQgTmXMr9PoPewyqsyHB4N0AB7nxDhtgmki0GniP2Lqtx3LJzOvQMjwet+I2lmWxvxwCg=="],
+
+    "@rspack/binding-linux-arm64-gnu": ["@rspack/binding-linux-arm64-gnu@2.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sU+jPGD2xz3BxFvsdBQVGce538YHqrSKMB4ZSfKhj6RSKjeGzpJ1BVl8+IndiQsfTgaUxi7N+r5cs/ezGy1TVQ=="],
+
+    "@rspack/binding-linux-arm64-musl": ["@rspack/binding-linux-arm64-musl@2.2.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-EQuADbqWbVgNAh5ep/u/B7Z/8UUkZjMLzHAOKZJklBpe4Y8mnhFNjieX0xc9NadR+drj9tqmEANxzTOkFtVPyQ=="],
+
+    "@rspack/binding-linux-ppc64-gnu": ["@rspack/binding-linux-ppc64-gnu@2.2.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kyXROzr519a5juBII9ysuc5ZD2apEZ0DJqL5PPCAOVHjzMfThEIBwnX3gicNCmp+kY0CCIOl2LagwbtFaOzoiA=="],
+
+    "@rspack/binding-linux-riscv64-gnu": ["@rspack/binding-linux-riscv64-gnu@2.2.3", "", { "os": "linux", "cpu": "none" }, "sha512-F3x6Nu0RUSoLtiaMse3hYQ3Nf5A2de6vTWWDXj14Ll6BpGWXGn+U/eXT/nB199fFnDEYf+CJEa7d6fzcYdwdjA=="],
+
+    "@rspack/binding-linux-riscv64-musl": ["@rspack/binding-linux-riscv64-musl@2.2.3", "", { "os": "linux", "cpu": "none" }, "sha512-O3HK7OnPvoBxZu4MX2j+t3gk4qiUsFYqj/29L3WgU1iQsdUSIN6PInW2JvbiLqyuzt09VltIEXTKayY8EysCpQ=="],
+
+    "@rspack/binding-linux-s390x-gnu": ["@rspack/binding-linux-s390x-gnu@2.2.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-SIxfGdwBdAjwJ8pDlPTb8MPIZIv/i2lKHn4/ywuDpFOxlUA4Bo/OKqQOenHx2MFD2mN8jigBZQTF0KVe5YP1uQ=="],
+
+    "@rspack/binding-linux-x64-gnu": ["@rspack/binding-linux-x64-gnu@2.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-IzQGcw09WYn/IzwB1SQpg7FQ211MBr+fJB2/WoRrPS6CNdtlkDHZaI8z2oq+2Oc5Su21jgX75VlWFajirUx5Dw=="],
+
+    "@rspack/binding-linux-x64-musl": ["@rspack/binding-linux-x64-musl@2.2.3", "", { "os": "linux", "cpu": "x64" }, "sha512-9OKSx2ickrR+PFal94XE6Hkj49AQ2HI3KuR9XeRkKOwSxjwrskV/Pn1wc2itDOHkm/QHP7k+MttsYb4FGuNIqw=="],
+
+    "@rspack/binding-wasm32-wasi": ["@rspack/binding-wasm32-wasi@2.2.3", "", { "dependencies": { "@emnapi/core": "1.11.3", "@emnapi/runtime": "1.11.3", "@napi-rs/wasm-runtime": "1.1.6" }, "cpu": "none" }, "sha512-gici3jWJi0GDy9kbYh57LoA57H8A2EAD9cV2jFKp1YoJ2aX2U9lANh4L+xoKPTvVQYpRvleoA5jkAvyfeLQ5bw=="],
+
+    "@rspack/binding-win32-arm64-msvc": ["@rspack/binding-win32-arm64-msvc@2.2.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-1MG66kcuqAGFs9ewiBc+/NJSTQr1jHrkZ2nCVMyhukl1o8embmFZa3BCibYgBYs5P7FRc6Sa+CDXcrfDZOLInQ=="],
+
+    "@rspack/binding-win32-ia32-msvc": ["@rspack/binding-win32-ia32-msvc@2.2.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-CAigxxh9DYJmEwH9f6FRkSsmt0GhKVqKaFRVFFrF9WDL7gXP3hyE/h/cCeMdmlTzRt8Mht87AvnDX7PG3neMrA=="],
+
+    "@rspack/binding-win32-x64-msvc": ["@rspack/binding-win32-x64-msvc@2.2.3", "", { "os": "win32", "cpu": "x64" }, "sha512-qa5Wc34a+Uux5foZ1Z+9fPQceVRbgTunaIulHezVF/ZxvqKO4DkAC7tFl53shB0YRVBAPg8R78MGd8cByfoxLQ=="],
+
+    "@rspack/cli": ["@rspack/cli@2.2.3", "", { "peerDependencies": { "@rspack/core": "^2.0.0-0", "@rspack/dev-server": "^2.0.0-0" }, "optionalPeers": ["@rspack/dev-server"], "bin": { "rspack": "./bin/rspack.js" } }, "sha512-EXMbWQt3neroH2zVfsJfY5u3U/IUJsalD27gj/Crl607WiSZODh5mNs18fcjWf56kc4l1G8aYFySC6WTw175VQ=="],
+
+    "@rspack/core": ["@rspack/core@2.2.3", "", { "dependencies": { "@rspack/binding": "2.2.3" }, "peerDependencies": { "@module-federation/runtime-tools": "^0.24.1 || ^2.0.0", "@swc/helpers": "^0.5.23" }, "optionalPeers": ["@module-federation/runtime-tools", "@swc/helpers"] }, "sha512-VHejw+PDd5B5v6VduFyjLSTIFaHBMNGPMKw+Y0zjkMqjYhDD1hjLOBC5frRKjTWcfYdk+Q73auWPp9k/H9PfIQ=="],
+
+    "@rspack/dev-middleware": ["@rspack/dev-middleware@2.0.4", "", { "peerDependencies": { "@rspack/core": "^2.0.0" }, "optionalPeers": ["@rspack/core"] }, "sha512-VCdT8hv9YvMPiBohhukD/OkGB+2GJ7mPRbeuDJ/jIT6hv5gvmJCnydMetJVARh6vXoBtfSHEd2gX78Dqaxh1NQ=="],
+
+    "@rspack/dev-server": ["@rspack/dev-server@2.2.1", "", { "dependencies": { "@rspack/dev-middleware": "^2.0.3" }, "peerDependencies": { "@rspack/core": "^2.0.0", "selfsigned": "^5.0.0" }, "optionalPeers": ["selfsigned"] }, "sha512-Il8HbYGK3rH5rM0XmUOsOGZVw69BKRpBZ61P28Fy8ry35CtfniDBWtbo/rvJtIT/sK0qwijmNrhF498ltsV+uA=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.13", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "big.js": ["big.js@5.2.2", "", {}, "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="],
+
+    "carbon-components-svelte": ["carbon-components-svelte@0.112.0", "", { "dependencies": { "@ibm/telemetry-js": "^1.5.0", "flatpickr": "4.6.9" } }, "sha512-7h+8EiCOFiaE4ydsLUyeAEn4R4p/XDAPYGORvTkLML0A6Vl49bW5JjrMukMHl+bnF8CIPA7nU3ZqqZYTUbCoPg=="],
+
+    "carbon-preprocess-svelte": ["carbon-preprocess-svelte@link:carbon-preprocess-svelte", {}],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "css-loader": ["css-loader@7.1.5", "", { "dependencies": { "icss-utils": "^5.1.0", "postcss": "^8.4.40", "postcss-modules-extract-imports": "^3.1.0", "postcss-modules-local-by-default": "^4.0.5", "postcss-modules-scope": "^3.2.0", "postcss-modules-values": "^4.0.0", "postcss-value-parser": "^4.2.0", "semver": "^7.6.3" }, "peerDependencies": { "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0", "webpack": "^5.27.0" }, "optionalPeers": ["@rspack/core", "webpack"] }, "sha512-Q7iAfQkU2twNBryKX/vGAlE+GAmkF7quhSzAGNK8fBimxk3+tqg245rH52UPb9dioBolBc8rP0ihmHBaDTJQBA=="],
+
+    "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
+
+    "devalue": ["devalue@5.9.2", "", {}, "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w=="],
+
+    "emojis-list": ["emojis-list@3.0.0", "", {}, "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.3.7", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-n2nf7fZR3c9yXf0BPEuHuXqT+KW0SJVj4cN5FMEkpCZ3scLjOQWpiccyCxVzCC2q1wubTghuEGzngJY/7Ah0Ow=="],
+
+    "flatpickr": ["flatpickr@4.6.9", "", {}, "sha512-F0azNNi8foVWKSF+8X+ZJzz8r9sE1G4hl06RyceIaLvyltKvDl6vqk9Lm/6AUUCi5HWaIjiUbk7UpeE/fOXOpw=="],
+
+    "icss-utils": ["icss-utils@5.1.0", "", { "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "loader-utils": ["loader-utils@2.0.4", "", { "dependencies": { "big.js": "^5.2.2", "emojis-list": "^3.0.0", "json5": "^2.1.2" } }, "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "nanoid": ["nanoid@3.3.19", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-Y2tUNy4ouw6tq5oDSKeQYGOyhkUBhNOcGV/02KC+6kd9eDGqdZd++mjMiIDilrBYvjEnCYvVtsuHCuP+okSfug=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "postcss": ["postcss@8.5.28", "", { "dependencies": { "nanoid": "^3.3.18", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A=="],
+
+    "postcss-modules-extract-imports": ["postcss-modules-extract-imports@3.1.0", "", { "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q=="],
+
+    "postcss-modules-local-by-default": ["postcss-modules-local-by-default@4.2.0", "", { "dependencies": { "icss-utils": "^5.0.0", "postcss-selector-parser": "^7.0.0", "postcss-value-parser": "^4.1.0" }, "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw=="],
+
+    "postcss-modules-scope": ["postcss-modules-scope@3.2.1", "", { "dependencies": { "postcss-selector-parser": "^7.0.0" }, "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA=="],
+
+    "postcss-modules-values": ["postcss-modules-values@4.0.0", "", { "dependencies": { "icss-utils": "^5.0.0" }, "peerDependencies": { "postcss": "^8.1.0" } }, "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ=="],
+
+    "postcss-selector-parser": ["postcss-selector-parser@7.1.6", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-7qASPzhKF2l2KLboRZux8CCTRMdGiV08vWmyKzPz22qZ7ZjQBOeY7rNzNoCLSUiftJ7HUq0GERHmxw/t0dCdMw=="],
+
+    "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "svelte": ["svelte@5.57.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg=="],
+
+    "svelte-dev-helper": ["svelte-dev-helper@1.1.9", "", {}, "sha512-oU+Xv7Dl4kRU2kdFjsoPLfJfnt5hUhsFUZtuzI3Ku/f2iAFZqBoEuXOqK3N9ngD4dxQOmN4OKWPHVi3NeAeAfQ=="],
+
+    "svelte-hmr": ["svelte-hmr@0.14.12", "", { "peerDependencies": { "svelte": ">=3.19.0" } }, "sha512-4QSW/VvXuqVcFZ+RhxiR8/newmwOCTlbYIezvkeN6302YFRE8cXy0naamHcjz8Y9Ce3ITTZtrHrIL0AGfyo61w=="],
+
+    "svelte-loader": ["svelte-loader@3.2.4", "", { "dependencies": { "loader-utils": "^2.0.4", "svelte-dev-helper": "^1.1.9", "svelte-hmr": "^0.14.2" }, "peerDependencies": { "svelte": "^3.0.0 || ^4.0.0-next.0 || ^5.0.0-next.1" } }, "sha512-e0HdDnkYH/MDx4/IfTSka5AOFg9yYJcPuoZJB5x0l60fkHjVjNvrrxr+rJegDG9J7ZymmdHt00/hdLw+QF299w=="],
+
+    "svelte-preprocess": ["svelte-preprocess@6.0.5", "", { "peerDependencies": { "@babel/core": "^7.10.2", "coffeescript": "^2.5.1", "less": "^3.11.3 || ^4.0.0", "postcss": "^7 || ^8", "postcss-load-config": ">=3", "pug": "^3.0.0", "sass": "^1.26.8", "stylus": ">=0.55", "sugarss": "^2.0.0 || ^3.0.0 || ^4.0.0", "svelte": "^4.0.0 || ^5.0.0-next.100 || ^5.0.0", "typescript": "^5.0.0 || ^6.0.0" }, "optionalPeers": ["@babel/core", "coffeescript", "less", "postcss", "postcss-load-config", "pug", "sass", "stylus", "sugarss", "typescript"] }, "sha512-sgwew5yV/2eMeQobIWgAxCNarKwiTUDIc3siAUbq3sp0G6ONtzk0W+wJihMdqjbYb3iGU3ubpGv0usnnuXT3qg=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "zimmerframe": ["zimmerframe@1.1.5", "", {}, "sha512-msJxIvYDYcoNL+PJsu+7qmpDWsYmAxTY+2TNYXXF0hzBzBk0BMecOqDOG/EckUoKCuKwObfbugIl8QpqHDXeFA=="],
+  }
+}

--- a/examples/rspack/package.json
+++ b/examples/rspack/package.json
@@ -1,0 +1,20 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "rspack dev",
+    "build": "NODE_ENV=production rspack build"
+  },
+  "devDependencies": {
+    "@rspack/cli": "latest",
+    "@rspack/core": "latest",
+    "@rspack/dev-server": "latest",
+    "carbon-components-svelte": "latest",
+    "carbon-preprocess-svelte": "link:carbon-preprocess-svelte",
+    "css-loader": "latest",
+    "svelte": "^5.57.0",
+    "svelte-loader": "latest",
+    "svelte-preprocess": "latest",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/rspack/rspack.config.mjs
+++ b/examples/rspack/rspack.config.mjs
@@ -1,0 +1,71 @@
+// @ts-check
+import path from "node:path";
+import { rspack } from "@rspack/core";
+import { OptimizeCssPlugin, optimizeImports } from "carbon-preprocess-svelte";
+import { sveltePreprocess } from "svelte-preprocess";
+
+/** @type {"development" | "production"} */
+const NODE_ENV =
+  process.env.NODE_ENV === "production" ? "production" : "development";
+const PROD = NODE_ENV === "production";
+
+/** @type {import("@rspack/core").Configuration} */
+export default {
+  entry: { "build/bundle": ["./src/index.ts"] },
+  resolve: {
+    extensions: [".mjs", ".js", ".svelte"],
+    conditionNames: ["svelte", "browser", "import"],
+  },
+  output: {
+    publicPath: "/",
+    path: path.resolve("./public"),
+    filename: PROD ? "[name].[contenthash].js" : "[name].js",
+    chunkFilename: "[name].[id].js",
+    clean: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.svelte$/,
+        use: {
+          loader: "svelte-loader",
+          options: {
+            hotReload: !PROD,
+            preprocess: [sveltePreprocess(), optimizeImports()],
+            compilerOptions: { dev: !PROD },
+          },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: [rspack.CssExtractRspackPlugin.loader, "css-loader"],
+      },
+      {
+        test: /node_modules\/svelte\/.*\.mjs$/,
+        resolve: { fullySpecified: false },
+      },
+    ],
+  },
+  mode: NODE_ENV,
+  plugins: [
+    new OptimizeCssPlugin(),
+    new rspack.CssExtractRspackPlugin({
+      filename: PROD ? "[name].[chunkhash].css" : "[name].css",
+    }),
+    new rspack.HtmlRspackPlugin({
+      templateContent: `
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        </head>
+        <body></body>
+      </html>
+      `,
+    }),
+  ],
+  stats: "errors-only",
+  devtool: PROD ? false : "source-map",
+  devServer: { hot: true, historyApiFallback: true },
+};

--- a/examples/rspack/src/App.svelte
+++ b/examples/rspack/src/App.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+  import "carbon-components-svelte/css/g100.css";
+  import { DataTable } from "carbon-components-svelte";
+</script>
+
+<DataTable
+  sortable
+  selectable
+  headers={[
+    { key: "name", value: "Name" },
+    { key: "protocol", value: "Protocol" },
+    { key: "port", value: "Port" },
+    { key: "rule", value: "Rule" },
+  ]}
+  rows={[
+    {
+      id: "a",
+      name: "Load Balancer 3",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin",
+    },
+    {
+      id: "b",
+      name: "Load Balancer 1",
+      protocol: "HTTP",
+      port: 443,
+      rule: "Round robin",
+    },
+    {
+      id: "c",
+      name: "Load Balancer 2",
+      protocol: "HTTP",
+      port: 80,
+      rule: "DNS delegation",
+    },
+    {
+      id: "d",
+      name: "Load Balancer 6",
+      protocol: "HTTP",
+      port: 3000,
+      rule: "Round robin",
+    },
+    {
+      id: "e",
+      name: "Load Balancer 4",
+      protocol: "HTTP",
+      port: 443,
+      rule: "Round robin",
+    },
+    {
+      id: "f",
+      name: "Load Balancer 5",
+      protocol: "HTTP",
+      port: 80,
+      rule: "DNS delegation",
+    },
+  ]}
+/>

--- a/examples/rspack/src/index.ts
+++ b/examples/rspack/src/index.ts
@@ -1,0 +1,4 @@
+import { mount } from "svelte";
+import App from "./App.svelte";
+
+mount(App, { target: document.body });

--- a/examples/rspack/tsconfig.json
+++ b/examples/rspack/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "optimize CSS",
     "vite",
     "rollup",
-    "webpack"
+    "webpack",
+    "rspack"
   ],
   "files": [
     "dist"

--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -1,4 +1,3 @@
-import type { Compiler } from "webpack";
 import { setComponents } from "../component-index-registry";
 import { ensureLiveComponentIndex } from "../indexer/live-index";
 import { isCarbonSvelteImport, isCssFile } from "../utils";
@@ -8,11 +7,58 @@ import { printDiff } from "./print-diff";
 import { scanContentClasses } from "./scan-content";
 
 /**
- * Webpack plugin that removes unused Carbon CSS classes from production builds.
+ * Structural subset of the webpack/Rspack `Compiler` and `Compilation` APIs
+ * used by this plugin. Rspack's compiler exposes the same `compiler.webpack`
+ * namespace (`Compilation`, `sources`, etc.) for plugin compatibility, so
+ * typing against this shape—rather than importing from the `webpack`
+ * package—lets the same plugin instance be used with either bundler without
+ * adding a dependency on either one.
+ */
+type WebpackAssetSource = {
+  source(): string | Buffer;
+};
+
+type WebpackCompilation = {
+  hooks: {
+    finishModules: {
+      tap(name: string, callback: (modules: Iterable<unknown>) => void): void;
+    };
+    processAssets: {
+      tapPromise(
+        options: { name: string; stage: number },
+        callback: (assets: Record<string, WebpackAssetSource>) => Promise<void>,
+      ): void;
+    };
+  };
+  updateAsset(name: string, source: unknown): void;
+};
+
+type WebpackCompiler = {
+  options: { mode?: string };
+  webpack: {
+    Compilation: { PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE: number };
+    sources: { RawSource: new (source: string) => unknown };
+  };
+  hooks: {
+    thisCompilation: {
+      tap(
+        name: string,
+        callback: (compilation: WebpackCompilation) => void,
+      ): void;
+    };
+  };
+};
+
+/**
+ * Webpack/Rspack plugin that removes unused Carbon CSS classes from production builds.
+ *
+ * Rspack aims for webpack plugin API compatibility, so this single plugin works
+ * with both bundlers unchanged.
  *
  * The plugin operates in two phases:
  * 1. During module processing, it collects all Carbon Svelte component file paths
- *    by inspecting each module's file dependencies in the `beforeSnapshot` hook.
+ *    by inspecting each module's `resource` in the `finishModules` hook, which
+ *    fires once every module in the graph has resolved.
  * 2. During asset processing, it uses PostCSS to strip CSS rules that don't match
  *    any classes used by the collected components.
  *
@@ -29,7 +75,7 @@ export default class OptimizeCssPlugin {
     };
   }
 
-  public apply(compiler: Compiler) {
+  public apply(compiler: WebpackCompiler) {
     if (compiler.options.mode !== "production") {
       return;
     }
@@ -37,7 +83,6 @@ export default class OptimizeCssPlugin {
     const {
       webpack: {
         Compilation,
-        NormalModule,
         sources: { RawSource },
       },
     } = compiler;
@@ -45,24 +90,27 @@ export default class OptimizeCssPlugin {
     compiler.hooks.thisCompilation.tap(
       OptimizeCssPlugin.name,
       (compilation) => {
-        const hooks = NormalModule.getCompilationHooks(compilation);
         const ids = new Set<string>();
 
         /**
-         * The `beforeSnapshot` hook fires after a module is built but before
-         * its snapshot is taken for caching. At this point, `buildInfo.fileDependencies`
-         * contains all files the module depends on, which includes imported Svelte components.
-         * Filter these to find Carbon component paths for the allowlist.
+         * `finishModules` fires once every module in the graph has resolved,
+         * so each imported Carbon Svelte component already exists as its own
+         * module with a `resource` (its resolved file path) set.
          */
-        hooks.beforeSnapshot.tap(OptimizeCssPlugin.name, ({ buildInfo }) => {
-          if (buildInfo?.fileDependencies) {
-            for (const id of buildInfo.fileDependencies) {
-              if (isCarbonSvelteImport(id)) {
-                ids.add(id);
+        compilation.hooks.finishModules.tap(
+          OptimizeCssPlugin.name,
+          (modules) => {
+            for (const module of modules) {
+              const resource = (module as { resource?: unknown }).resource;
+              if (
+                typeof resource === "string" &&
+                isCarbonSvelteImport(resource)
+              ) {
+                ids.add(resource);
               }
             }
-          }
-        });
+          },
+        );
 
         /**
          * Process assets at OPTIMIZE_SIZE stage, which runs after the CSS has been

--- a/tests/OptimizeCssPlugin.test.ts
+++ b/tests/OptimizeCssPlugin.test.ts
@@ -6,16 +6,21 @@ import OptimizeCssPlugin from "../src/plugins/OptimizeCssPlugin";
 const createMockCompiler = (
   options: {
     assets?: Record<string, unknown>;
-    fileDependencies?: string[];
+    moduleResources?: string[];
     mode?: "production" | "development" | "none";
   } = {},
 ) => {
-  const { assets = {}, fileDependencies = [], mode = "production" } = options;
+  const { assets = {}, moduleResources = [], mode = "production" } = options;
 
   let processAssetsPromise: Promise<void> | null = null;
 
   const compilation = {
     hooks: {
+      finishModules: {
+        tap: jest.fn((_, callback) => {
+          callback(moduleResources.map((resource) => ({ resource })));
+        }),
+      },
       processAssets: {
         tapPromise: jest.fn((_, callback) => {
           processAssetsPromise = callback(assets);
@@ -23,14 +28,6 @@ const createMockCompiler = (
       },
     },
     updateAsset: jest.fn(),
-  };
-
-  const normalModuleHooks = {
-    beforeSnapshot: {
-      tap: jest.fn((_, callback) => {
-        callback({ buildInfo: { fileDependencies } });
-      }),
-    },
   };
 
   return {
@@ -45,15 +42,11 @@ const createMockCompiler = (
         PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE:
           "PROCESS_ASSETS_STAGE_OPTIMIZE_SIZE",
       },
-      NormalModule: {
-        getCompilationHooks: () => normalModuleHooks,
-      },
       sources: {
         RawSource: jest.fn((content) => ({ source: () => content })),
       },
     },
     compilation,
-    normalModuleHooks,
     waitForProcessAssets: () => processAssetsPromise,
   };
 };
@@ -89,7 +82,7 @@ describe("OptimizeCssPlugin", () => {
     const plugin = new OptimizeCssPlugin();
     const mockCompiler = createMockCompiler({
       assets: { "styles.css": { source: () => ".bx--btn { color: blue; }" } },
-      fileDependencies: ["node_modules/carbon-components-svelte/Button.svelte"],
+      moduleResources: ["node_modules/carbon-components-svelte/Button.svelte"],
       mode: "development",
     });
 
@@ -101,7 +94,7 @@ describe("OptimizeCssPlugin", () => {
     const plugin = new OptimizeCssPlugin();
     const mockCompiler = createMockCompiler({
       assets: { "styles.css": { source: () => "body { color: red; }" } },
-      fileDependencies: ["regular-component.svelte"],
+      moduleResources: ["regular-component.svelte"],
     });
 
     plugin.apply(asCompiler(mockCompiler));
@@ -117,7 +110,7 @@ describe("OptimizeCssPlugin", () => {
       assets: {
         "styles.css": { source: () => cssContent },
       },
-      fileDependencies: [carbonComponent],
+      moduleResources: [carbonComponent],
     });
 
     plugin.apply(asCompiler(mockCompiler));
@@ -138,7 +131,7 @@ describe("OptimizeCssPlugin", () => {
       assets: {
         "styles.css": { source: () => cssContent },
       },
-      fileDependencies: [carbonComponent],
+      moduleResources: [carbonComponent],
     });
 
     plugin.apply(asCompiler(mockCompiler));
@@ -163,7 +156,7 @@ describe("OptimizeCssPlugin", () => {
       assets: {
         "styles.css": { source: () => cssWithUnusedCarbon },
       },
-      fileDependencies: [carbonComponent],
+      moduleResources: [carbonComponent],
     });
 
     plugin.apply(asCompiler(mockCompiler));
@@ -186,7 +179,7 @@ describe("OptimizeCssPlugin", () => {
       assets: {
         "styles.css": { source: () => cssWithOnlyUsedCarbon },
       },
-      fileDependencies: [carbonComponent],
+      moduleResources: [carbonComponent],
     });
 
     plugin.apply(asCompiler(mockCompiler));
@@ -206,7 +199,7 @@ describe("OptimizeCssPlugin", () => {
       assets: {
         "styles.css": { source: () => cssContent },
       },
-      fileDependencies: [carbonComponent],
+      moduleResources: [carbonComponent],
     });
 
     plugin.apply(asCompiler(mockCompiler));

--- a/tests/__snapshots__/e2e.json
+++ b/tests/__snapshots__/e2e.json
@@ -5,6 +5,12 @@
     "after_kb": 49.42,
     "reduction_percent": 93.04
   },
+  "rspack": {
+    "file": "build/bundle.*.css",
+    "before_kb": 831.66,
+    "after_kb": 53.09,
+    "reduction_percent": 93.62
+  },
   "sveltekit": {
     "file": "_app/immutable/assets/2.*.css",
     "before_kb": 695.03,


### PR DESCRIPTION
OptimizeCssPlugin collected imported Carbon Svelte component paths
via NormalModule's `beforeSnapshot` hook, which Rspack doesn't
implement. Switching to `finishModules` also uncovered a latent bug
on real webpack builds: `buildInfo.fileDependencies` isn't actually
populated yet at that point, so the plugin was silently a no-op in
some cases. It now reads each module's `resource` directly, which
works identically on both bundlers.

```js
// rspack.config.mjs
import { OptimizeCssPlugin } from "carbon-preprocess-svelte";

export default {
  plugins: [new OptimizeCssPlugin()],
};
```