### PR TITLE
fix(optimize-css): reset tracked ids/content cache per Vite build

### DIFF
--- a/src/plugins/optimize-css.ts
+++ b/src/plugins/optimize-css.ts
@@ -34,13 +34,18 @@ export const optimizeCss = (options?: OptimizeCssOptions): Plugin => {
     apply: "build",
     enforce: "post",
     /**
-     * Runs once before any module is transformed. When
-     * `experimental.liveIndex` is set, this is where the component index
-     * gets rebuilt from the project's installed `carbon-components-svelte`
-     * (or read from cache), so it's ready before `transform`/`generateBundle`
-     * ever consult it.
+     * Runs once before any module is transformed. Resets state tracked from
+     * a prior build so `vite build --watch` rebuilds (which reuse this same
+     * plugin instance) don't leak component ids or a stale content scan into
+     * the next build. When `experimental.liveIndex` is set, this is also
+     * where the component index gets rebuilt from the project's installed
+     * `carbon-components-svelte` (or read from cache), so it's ready before
+     * `transform`/`generateBundle` ever consult it.
      */
     async buildStart() {
+      ids.clear();
+      contentClasses = undefined;
+
       if (options?.experimental?.liveIndex) {
         setComponents(await ensureLiveComponentIndex());
       }

--- a/tests/optimize-css.test.ts
+++ b/tests/optimize-css.test.ts
@@ -1,0 +1,75 @@
+import type { Rollup } from "vite";
+import { CarbonSvelte } from "../src/constants";
+import { optimizeCss } from "../src/plugins/optimize-css";
+
+type OutputAsset = Rollup.OutputAsset;
+type OutputBundle = Rollup.OutputBundle;
+
+const carbonComponent = `node_modules/${CarbonSvelte.Components}/Button.svelte`;
+
+function makeCssBundle(source: string): OutputBundle {
+  return {
+    "styles.css": {
+      type: "asset",
+      source,
+    } as OutputAsset,
+  } as unknown as OutputBundle;
+}
+
+describe("optimizeCss (Vite plugin)", () => {
+  test("prunes unused Carbon classes when a component is imported", async () => {
+    const plugin = optimizeCss({ silent: true });
+    const cssContent = `.bx--btn { color: blue }
+.bx--accordion { background: yellow }`;
+
+    // @ts-expect-error - hooks are plain functions on this plugin
+    await plugin.buildStart();
+    // @ts-expect-error
+    plugin.transform("", carbonComponent);
+
+    const bundle = makeCssBundle(cssContent);
+    // @ts-expect-error
+    await plugin.generateBundle({}, bundle);
+
+    expect((bundle["styles.css"] as OutputAsset).source).toEqual(
+      ".bx--btn { color: blue }",
+    );
+  });
+
+  test("does not leak imported component ids into the next build", async () => {
+    // Regression test: a long-running `vite build --watch` session reuses the
+    // same plugin instance across rebuilds. If tracked ids aren't reset, a
+    // component removed from the app in a later rebuild still keeps its CSS
+    // classes alive, silently degrading optimization over time.
+    const plugin = optimizeCss({ silent: true });
+    const cssContent = `.bx--btn { color: blue }
+.bx--accordion { background: yellow }`;
+
+    // First build: Button is imported.
+    // @ts-expect-error
+    await plugin.buildStart();
+    // @ts-expect-error
+    plugin.transform("", carbonComponent);
+    const firstBundle = makeCssBundle(cssContent);
+    // @ts-expect-error
+    await plugin.generateBundle({}, firstBundle);
+    expect((firstBundle["styles.css"] as OutputAsset).source).toEqual(
+      ".bx--btn { color: blue }",
+    );
+
+    // Second build (rebuild): Button is no longer imported, so `transform`
+    // never fires for it this time around.
+    // @ts-expect-error
+    await plugin.buildStart();
+    const secondBundle = makeCssBundle(cssContent);
+    // @ts-expect-error
+    await plugin.generateBundle({}, secondBundle);
+
+    // No Carbon components are tracked anymore, so the plugin should skip
+    // optimization entirely and leave the CSS untouched (per the "Skip
+    // processing if no Carbon Svelte imports are found" early return).
+    expect((secondBundle["styles.css"] as OutputAsset).source).toEqual(
+      cssContent,
+    );
+  });
+});


### PR DESCRIPTION
The Vite plugin's ids Set and contentClasses cache lived in the outer
factory closure, so a persistent plugin instance across `vite build
--watch` rebuilds kept accumulating component ids instead of
reflecting the current build.

Concretely: rebuild 1 imports Button, so `.bx--btn` gets allowlisted.
If a later rebuild removes the Button import entirely, the ids Set
still has Button's path in it (nothing ever cleared it), so
`.bx--btn` keeps getting preserved in every CSS asset from then on,
even though no code references it anymore. The bundle just quietly
carries dead CSS for the rest of the watch session, with no error or
signal that anything's wrong, since the plugin instance is created
once per `vite build --watch` invocation and reused for every
rebuild.

The webpack/Rspack plugin doesn't have this problem: it creates a
fresh ids Set inside `thisCompilation.tap`, which fires per
compilation. This brings the Vite plugin's `buildStart` in line with
that by clearing `ids` and dropping the cached `contentClasses` at
the start of every build.

Added a regression test that runs two simulated builds through the
same plugin instance, the second with the component import removed,
and asserts the second build's CSS is left untouched instead of
still pruning based on stale state.