### PR TITLE
perf: faster CSS pruning, import source maps, and index build

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -2,9 +2,9 @@
 
 [ostia](https://github.com/metonym/ostia) benchmarks for the three hot paths in this package:
 
-- `optimize-css.bench.ts` — `optimizeCssWithReport` against Carbon's real compiled stylesheet (`carbon-components-svelte/css/white.css`), across a small/medium/large import bundle. Runs on every build, once per CSS asset.
-- `optimize-imports.bench.ts` — the `optimizeImports` script preprocessor, across a no-op skip path and small/medium/large import counts. Runs on every `.svelte` file with a `carbon-` substring, on every build and HMR update.
-- `build-index.bench.ts` — `buildComponentIndex`, a full re-scan of an installed `carbon-components-svelte` (file scan + CSS indexing + runtime-class graph). Coarser than the other two: it does real file I/O, so treat it as an end-to-end baseline rather than a tight microbenchmark. Also prints a one-off phase breakdown (scan / css index / runtime graph) to point at where time goes.
+- `optimize-css.bench.ts` — `optimizeCssWithReport` against Carbon's real compiled stylesheet (`carbon-components-svelte/css/white.css`), across a small/medium/large import bundle. Runs on every build, once per CSS asset. Further groups cover every branch a CSS asset can take through `createCssOptimizer().run` (a non-Carbon chunk that is skipped, Carbon concatenated with app CSS on the splice path, an `@layer` stylesheet that falls back to PostCSS, and a `Uint8Array` source), the options that add per-selector work (`safelist` strings and RegExps, `contentClasses`, `DatePicker`, `preserveAllIBMFonts`), one optimizer run over a whole four-asset bundle, and `scanContentClasses` over 200 generated source files.
+- `optimize-imports.bench.ts` — the `optimizeImports` script preprocessor, across a no-op skip path, a `carbon-` file that is already rewritten, small/medium/large import counts, and mixed specifiers (aliases, `type`, un-indexed utilities). Runs on every `.svelte` file with a `carbon-` substring, on every build and HMR update. The second group appends a 300-line script body: the source map covers every line after the rewritten imports, so on real files the body length dominates, not the import count.
+- `build-index.bench.ts` — `buildComponentIndex`, a full re-scan of an installed `carbon-components-svelte` (file scan + CSS indexing + runtime-class graph). Coarser than the other two: it does real file I/O, so treat it as an end-to-end baseline rather than a tight microbenchmark. A second group runs each phase on its own (the `src` walk, `extractFromSvelte` on a small and a large component, `extractCssIndexAdditions` on the real stylesheet, and `buildRuntimeClassMap` with the Svelte import graph pre-scanned, as the full build hands it over). Also prints a one-off phase breakdown (scan / css index / runtime graph) to point at where time goes; the CSS index and runtime graph run concurrently there, so their numbers overlap.
 
 ## Running
 
@@ -21,4 +21,5 @@ ostia bench bench/optimize-imports.bench.ts --filter "medium|large"  # run a sub
 
 - Numbers are machine-relative, not absolute. Use them to compare before/after a change on the same machine, not across machines.
 - `optimize-css` and `build-index` don't mutate shared state between iterations (each call gets a fresh allowlist / index), so results aren't skewed by warm caches inside the library itself — only by the OS file cache for `build-index`.
-- When investigating a regression, run the relevant `bench:*` script before and after your change and compare `Mean`/`Min…Max`.
+- When investigating a regression, run the relevant `bench:*` script before and after your change and compare `Median`/`Range`. `--export-json before.json` on the baseline and `ostia compare before.json after.json` gives a noise-aware verdict; `--cpu` adds a hotspot list per task.
+- `--alloc` reports retained heap per call after a forced GC, which is near zero for these tasks (nothing survives a call); it does not measure allocation volume.

--- a/bench/build-index.bench.ts
+++ b/bench/build-index.bench.ts
@@ -1,5 +1,26 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
 import { group, task } from "ostia";
-import { buildComponentIndex } from "../src/indexer/build-index";
+import { getComponents } from "../src/component-index-registry";
+import { CarbonSvelte } from "../src/constants";
+import {
+  buildComponentIndex,
+  resolveCarbonRoot,
+} from "../src/indexer/build-index";
+import {
+  extractCssIndexAdditions,
+  resolveCarbonCssPath,
+} from "../src/indexer/extract-css-context";
+import {
+  buildRuntimeClassMap,
+  type ModuleGraphCache,
+} from "../src/indexer/extract-runtime-classes";
+import { extractFromSvelte } from "../src/indexer/extract-selectors";
+import { listJsAndSvelteFiles } from "../src/indexer/list-files";
+import { isSvelteFile } from "../src/utils";
+
+const carbonRoot = resolveCarbonRoot();
+const carbonSrc = path.join(carbonRoot, "src");
 
 // Rebuilds the full component index from the installed `carbon-components-svelte`
 // (file scan + CSS indexing + runtime-class graph). Runs once per build normally,
@@ -8,6 +29,86 @@ import { buildComponentIndex } from "../src/indexer/build-index";
 group("buildComponentIndex (full scan)", () => {
   task("cold-ish rebuild", async () => {
     await buildComponentIndex();
+  });
+});
+
+// The phases behind the aggregate, each on the same real inputs the full
+// build uses, so a regression can be pinned to one of them.
+const DATA_TABLE = readFileSync(
+  path.join(carbonSrc, "DataTable/DataTable.svelte"),
+  "utf8",
+);
+const BUTTON = readFileSync(
+  path.join(carbonSrc, "Button/Button.svelte"),
+  "utf8",
+);
+const carbonCss = readFileSync(resolveCarbonCssPath(carbonRoot), "utf8");
+
+// Inputs for the CSS pass, derived from the frozen index: every exported
+// component's classes, keyed the way `buildComponentIndex` keys them.
+const components = getComponents();
+const componentClasses = new Map<string, Set<string>>();
+const moduleToComponent = new Map<string, string>();
+const srcPrefix = `${CarbonSvelte.Components}/src/`;
+for (const [name, entry] of Object.entries(components)) {
+  componentClasses.set(name, new Set(entry.classes));
+  if (entry.path.endsWith(".svelte")) {
+    moduleToComponent.set(entry.path.slice(srcPrefix.length), name);
+  }
+}
+
+// The full build hands `buildRuntimeClassMap` the import graph of every
+// `.svelte` module it already parsed, so only `.js` utilities get loaded
+// on demand. Reproduce that once here; each trial starts from a copy.
+const files = await listJsAndSvelteFiles(carbonSrc);
+const scanned: ModuleGraphCache = {
+  importsByModule: new Map(),
+  runtimeByModule: new Map(),
+  files: new Set(files),
+};
+for (const file of files) {
+  if (file.startsWith("icons/") || !isSvelteFile(file)) continue;
+  const extracted = extractFromSvelte({
+    code: readFileSync(path.join(carbonSrc, file), "utf8"),
+    filename: file,
+  });
+  scanned.importsByModule.set(file, extracted.imports);
+  if (extracted.runtimeClasses.length > 0) {
+    scanned.runtimeByModule.set(file, new Set(extracted.runtimeClasses));
+  }
+}
+
+group("buildComponentIndex phases", () => {
+  task("listJsAndSvelteFiles (src walk)", async () => {
+    await listJsAndSvelteFiles(carbonSrc);
+  });
+
+  task("extractFromSvelte (Button.svelte)", () => {
+    extractFromSvelte({ code: BUTTON, filename: "Button/Button.svelte" });
+  });
+
+  task("extractFromSvelte (DataTable.svelte)", () => {
+    extractFromSvelte({
+      code: DATA_TABLE,
+      filename: "DataTable/DataTable.svelte",
+    });
+  });
+
+  task("extractCssIndexAdditions (white.css)", () => {
+    extractCssIndexAdditions({
+      componentClasses,
+      slotWrapperClasses: new Map(),
+      subComponents: new Map(),
+      css: carbonCss,
+    });
+  });
+
+  task("buildRuntimeClassMap (svelte graph pre-scanned)", async () => {
+    await buildRuntimeClassMap(carbonSrc, moduleToComponent, {
+      importsByModule: new Map(scanned.importsByModule),
+      runtimeByModule: new Map(scanned.runtimeByModule),
+      files: scanned.files,
+    });
   });
 });
 

--- a/bench/optimize-css.bench.ts
+++ b/bench/optimize-css.bench.ts
@@ -1,10 +1,45 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { group, task } from "ostia";
-import { optimizeCssWithReport } from "../src/plugins/create-optimized-css";
+import {
+  createCssOptimizer,
+  optimizeCssWithReport,
+} from "../src/plugins/create-optimized-css";
+import { scanContentClasses } from "../src/plugins/scan-content";
 import { resolveCarbonCss } from "../tests/helpers/carbon-css";
 
 // Real Carbon theme CSS (~700kb minified), same source the plugin optimizes
 // at build time. Any theme works for selector coverage.
 const source = resolveCarbonCss("white");
+
+/**
+ * Synthetic app CSS with no Carbon classes: the shape of a per-route chunk
+ * (utility classes, a media query, a few custom properties). `rules` scales
+ * the size; 400 rules is ~25kb.
+ */
+function appCss(rules: number, prefix = "app"): string {
+  let css = ":root{--app-gap:8px;--app-radius:4px}";
+  for (let i = 0; i < rules; i++) {
+    css += `.${prefix}-card-${i}{display:flex;gap:var(--app-gap);padding:${i % 32}px;border-radius:var(--app-radius);color:#161616}`;
+    css += `.${prefix}-card-${i}:hover,.${prefix}-card-${i}:focus-visible{outline:2px solid #0f62fe}`;
+    if (i % 8 === 0) {
+      css += `@media (min-width:${640 + i}px){.${prefix}-card-${i}{padding:${i % 16}px}}`;
+    }
+  }
+  return css;
+}
+
+const APP_CHUNK = appCss(400);
+const APP_CHUNK_ROUTE_2 = appCss(120, "route");
+const APP_CHUNK_ROUTE_3 = appCss(40, "widget");
+// One bundled asset: Carbon theme followed by the app's own styles. Vite
+// concatenates imported stylesheets in import order.
+const CARBON_PLUS_APP = `${source}\n${APP_CHUNK}`;
+// `@layer` (e.g. from Tailwind v4) is outside the splice optimizer's modeled
+// shape, so the whole asset goes through the PostCSS reference pipeline.
+const CARBON_PLUS_LAYER = `${source}\n@layer base{${APP_CHUNK}}`;
+const SOURCE_BYTES = new TextEncoder().encode(source);
 
 type Scenario = { name: string; ids: string[] };
 
@@ -31,3 +66,131 @@ for (const scenario of SCENARIOS) {
     });
   });
 }
+
+const BUNDLE_IDS = ["DataTable", "Toolbar", "ToolbarSearch", "OverflowMenu"];
+const SAFELIST_REGEXPS = [/^\.bx--btn--/, /bx--tag/];
+
+// Every CSS asset in a build goes through `run`, not just the Carbon theme.
+// These cover each branch of that call: the no-Carbon skip, the splice path
+// on a mixed asset, the PostCSS fallback, and the raw-bytes input Vite hands
+// over for emitted assets.
+group("per-asset paths (small bundle)", () => {
+  const optimizer = createCssOptimizer({ ids: BUNDLE_IDS, silent: true });
+
+  task("non-Carbon chunk (skip, ~25kb)", () => {
+    optimizer.run(APP_CHUNK, "chunk.css");
+  });
+
+  task("Carbon + app CSS (splice)", () => {
+    optimizer.run(CARBON_PLUS_APP, "index.css");
+  });
+
+  task("Carbon + @layer (PostCSS fallback)", () => {
+    optimizer.run(CARBON_PLUS_LAYER, "index.css");
+  });
+
+  task("Carbon as Uint8Array", () => {
+    optimizer.run(SOURCE_BYTES, "index.css");
+  });
+});
+
+// Options that widen the allowlist or add per-selector work.
+group("options (small bundle)", () => {
+  task("safelist: strings", () => {
+    optimizeCssWithReport({
+      source,
+      ids: BUNDLE_IDS,
+      silent: true,
+      safelist: [".bx--grid", ".bx--row", ".bx--col", ".bx--aspect-ratio"],
+    });
+  });
+
+  task("safelist: RegExp", () => {
+    optimizeCssWithReport({
+      source,
+      ids: BUNDLE_IDS,
+      silent: true,
+      safelist: SAFELIST_REGEXPS,
+    });
+  });
+
+  task("contentClasses: 300 tokens", () => {
+    optimizeCssWithReport({
+      source,
+      ids: BUNDLE_IDS,
+      silent: true,
+      contentClasses: CONTENT_CLASSES,
+    });
+  });
+
+  task("DatePicker (flatpickr kept)", () => {
+    optimizeCssWithReport({
+      source,
+      ids: [...BUNDLE_IDS, "DatePicker", "DatePickerInput"],
+      silent: true,
+    });
+  });
+
+  task("preserveAllIBMFonts", () => {
+    optimizeCssWithReport({
+      source,
+      ids: BUNDLE_IDS,
+      silent: true,
+      preserveAllIBMFonts: true,
+    });
+  });
+});
+
+// A whole `generateBundle`: one optimizer, every CSS asset in the output.
+group("full build (small bundle, 4 assets)", () => {
+  const assets = [
+    ["index.css", CARBON_PLUS_APP],
+    ["route-2.css", APP_CHUNK_ROUTE_2],
+    ["route-3.css", APP_CHUNK_ROUTE_3],
+    ["vendor.css", APP_CHUNK],
+  ] as const;
+
+  task("createCssOptimizer + run each asset", () => {
+    const optimizer = createCssOptimizer({ ids: BUNDLE_IDS, silent: true });
+    for (const [id, css] of assets) {
+      optimizer.run(css, id);
+    }
+  });
+});
+
+/**
+ * `.bx--*` tokens as `scanContentClasses` would find them in app markup:
+ * a few hundred distinct tokens, some of them `-` prefixes.
+ */
+const CONTENT_CLASSES = Array.from({ length: 300 }, (_, i) =>
+  i % 10 === 0 ? `.bx--content-${i}-` : `.bx--content-${i}`,
+);
+
+// `content` globs are scanned once per build. 200 source files with a
+// handful of Carbon tokens each.
+const contentDir = mkdtempSync(join(tmpdir(), "cps-bench-content-"));
+for (let i = 0; i < 200; i++) {
+  const body = Array.from(
+    { length: 40 },
+    (_, line) =>
+      `<div class="bx--grid bx--row-${line % 7} app-${i}-${line}">${"x".repeat(60)}</div>`,
+  ).join("\n");
+  writeFileSync(
+    join(contentDir, `Page${i}.svelte`),
+    `<script>\n  let kind = "primary";\n</script>\n${body}\n<button class={\`bx--btn--\${kind}\`} />\n`,
+  );
+}
+
+group(
+  "content scan",
+  () => {
+    task("scanContentClasses (200 files)", () => {
+      scanContentClasses([join(contentDir, "*.svelte")]);
+    });
+  },
+  {
+    after() {
+      rmSync(contentDir, { recursive: true, force: true });
+    },
+  },
+);

--- a/bench/optimize-imports.bench.ts
+++ b/bench/optimize-imports.bench.ts
@@ -21,6 +21,14 @@ onMount(() => {
   count += 1;
 });`;
 
+// Already rewritten (or hand-written) direct imports: the `carbon-` substring
+// is present, so the fast path can't skip, but nothing changes.
+const ALREADY_DIRECT = `import Button from "carbon-components-svelte/src/Button/Button.svelte";
+import TextInput from "carbon-components-svelte/src/TextInput/TextInput.svelte";
+import Add from "carbon-icons-svelte/lib/Add.svelte";
+
+let value = "";`;
+
 const SMALL = `import { Button, TextInput } from "carbon-components-svelte";`;
 
 const MEDIUM = `import {
@@ -34,6 +42,18 @@ const MEDIUM = `import {
   Checkbox,
 } from "carbon-components-svelte";
 import { Add, Close, Edit } from "carbon-icons-svelte";`;
+
+// Aliases, per-specifier `type`, an un-indexed camelCase utility that stays
+// on the barrel, and a type-only statement that must be left alone.
+const MIXED = `import type { DataTableRow } from "carbon-components-svelte";
+import {
+  Button as CarbonButton,
+  type ButtonProps,
+  TextInput,
+  truncate,
+  DataTable,
+} from "carbon-components-svelte";
+import { Add as AddIcon, Close } from "carbon-icons-svelte";`;
 
 // Representative of a large dashboard page with many Carbon imports.
 const LARGE = `import {
@@ -103,9 +123,39 @@ import {
 } from "carbon-icons-svelte";
 import { Airplane, Analytics } from "carbon-pictograms-svelte";`;
 
+/**
+ * A realistic component script: the medium import block followed by ~300
+ * lines of ordinary code. The source map has to cover every line after the
+ * rewritten imports, so the body length, not the import count, is what
+ * dominates for real files.
+ */
+const BODY_LINES = 300;
+const BODY = Array.from({ length: BODY_LINES }, (_, i) => {
+  switch (i % 6) {
+    case 0:
+      return `  let value${i} = $state("");`;
+    case 1:
+      return `  const rows${i} = data.map((row, index) => ({ ...row, id: \`row-\${index}-${i}\` }));`;
+    case 2:
+      return `  function onSelect${i}(event) {`;
+    case 3:
+      return `    selected = event.detail.selectedRowIds.filter((id) => id !== ${i});`;
+    case 4:
+      return "  }";
+    default:
+      return `  // ${"comment text ".repeat(4)}${i}`;
+  }
+}).join("\n");
+const MEDIUM_WITH_BODY = `${MEDIUM}\n\n${BODY}\n`;
+const LARGE_WITH_BODY = `${LARGE}\n\n${BODY}\n`;
+
 group("optimizeImports script preprocessor", () => {
   task("no carbon- substring (skip fast path)", () => {
     preprocess(NO_CARBON);
+  });
+
+  task("carbon- present, already direct (no rewrite)", () => {
+    preprocess(ALREADY_DIRECT);
   });
 
   task("small (2 imports)", () => {
@@ -116,7 +166,21 @@ group("optimizeImports script preprocessor", () => {
     preprocess(MEDIUM);
   });
 
+  task("mixed (aliases, type, utility)", () => {
+    preprocess(MIXED);
+  });
+
   task("large (60+ imports)", () => {
     preprocess(LARGE);
+  });
+});
+
+group("optimizeImports with a component body (source map)", () => {
+  task(`medium (11 imports) + ${BODY_LINES}-line body`, () => {
+    preprocess(MEDIUM_WITH_BODY);
+  });
+
+  task(`large (60+ imports) + ${BODY_LINES}-line body`, () => {
+    preprocess(LARGE_WITH_BODY);
   });
 });

--- a/src/indexer/build-index.ts
+++ b/src/indexer/build-index.ts
@@ -92,6 +92,7 @@ export async function buildComponentIndex(options?: {
 
   const scanStart = performance.now();
   const files = await listFiles(carbon_src);
+  moduleGraph.files = new Set(files);
 
   const extractedByFile = new Map<string, ReturnType<typeof extractFromSvelte>>(
     (

--- a/src/indexer/css-selector-utils.ts
+++ b/src/indexer/css-selector-utils.ts
@@ -3,7 +3,7 @@ const OPEN_PAREN = 40;
 const CLOSE_PAREN = 41;
 
 /** `[A-Za-z0-9_-]`: the characters that continue a class token. */
-function isClassTokenChar(code: number): boolean {
+export function isClassTokenChar(code: number): boolean {
   return (
     (code >= 97 && code <= 122) ||
     (code >= 65 && code <= 90) ||
@@ -49,7 +49,7 @@ export function splitSelectorList(selector: string): string[] {
 }
 
 /** Drop `:not(...)` subtrees before class extraction. */
-function stripNotPseudoClasses(selector: string): string {
+export function stripNotPseudoClasses(selector: string): string {
   let index = selector.indexOf(":not(");
   if (index === -1) return selector;
 
@@ -120,6 +120,38 @@ export function getCarbonClassesFromNormalized(normalized: string): string[] {
   }
 
   return classes;
+}
+
+/**
+ * Offset where the subject compound starts in a `:not(...)`-free selector:
+ * the last compound after a depth-0 combinator, skipping empty compounds
+ * (runs of combinator characters), exactly as `splitSelectorParts` picks its
+ * `subject`. Everything before it is the ancestor compounds and the
+ * combinators between them; `0` when the selector is a single compound.
+ */
+export function findSubjectStart(normalized: string): number {
+  const length = normalized.length;
+  let subjectStart = 0;
+  let depth = 0;
+  let start = 0;
+
+  for (let i = 0; i <= length; i++) {
+    const code = i < length ? normalized.charCodeAt(i) : -1;
+
+    if (code === OPEN_PAREN) {
+      depth++;
+    } else if (code === CLOSE_PAREN) {
+      if (depth > 0) depth--;
+    } else if (
+      i === length ||
+      (depth === 0 && code < 128 && COMBINATOR_CHARS[code] === 1)
+    ) {
+      if (i > start) subjectStart = start;
+      start = i + 1;
+    }
+  }
+
+  return subjectStart;
 }
 
 /** Split a selector branch into ancestor compounds and the subject compound. */

--- a/src/indexer/extract-css-context.ts
+++ b/src/indexer/extract-css-context.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import postcss from "postcss";
+import { forEachRuleSelector } from "../plugins/css-splice-optimizer";
 import {
   getCarbonClassesFromNormalized,
   splitSelectorList,
@@ -36,6 +37,11 @@ function walkCarbonRules(
   css: string,
   onRule: (selector: string) => void,
 ): void {
+  // Compiled Carbon themes fit the splice parser's shape, which enumerates
+  // rules several times faster than a PostCSS AST; anything else parses
+  // with PostCSS.
+  if (forEachRuleSelector(css, onRule)) return;
+
   const root = postcss.parse(css);
   root.walkRules((rule) => {
     onRule(rule.selector);

--- a/src/indexer/extract-runtime-classes.ts
+++ b/src/indexer/extract-runtime-classes.ts
@@ -80,6 +80,13 @@ function collectImportsFromCode(
 export type ModuleGraphCache = {
   importsByModule: Map<string, string[]>;
   runtimeByModule: Map<string, Set<string>>;
+  /**
+   * Every `.js`/`.svelte` module key under the Carbon `src` directory, when
+   * the caller has already listed them. Import resolution then never touches
+   * the filesystem; without it, each candidate path is checked with
+   * `existsSync`.
+   */
+  files?: Set<string>;
 };
 
 function importCandidates(spec: string): string[] {
@@ -101,6 +108,7 @@ function resolveExistingModuleKey(
   carbonSrcPath: string,
   moduleKey: string,
   cache: Map<string, string | null>,
+  files: Set<string> | undefined,
 ): string | null {
   const cached = cache.get(moduleKey);
   if (cached !== undefined) return cached;
@@ -108,7 +116,10 @@ function resolveExistingModuleKey(
   let resolved: string | null = null;
 
   for (const candidate of importCandidates(moduleKey)) {
-    if (existsSync(path.join(carbonSrcPath, candidate))) {
+    const exists = files
+      ? files.has(candidate)
+      : existsSync(path.join(carbonSrcPath, candidate));
+    if (exists) {
       resolved = candidate;
       break;
     }
@@ -127,7 +138,7 @@ export async function buildRuntimeClassMap(
   moduleToComponent: Map<string, string>,
   cache: ModuleGraphCache,
 ): Promise<Map<string, Set<string>>> {
-  const { importsByModule, runtimeByModule } = cache;
+  const { importsByModule, runtimeByModule, files } = cache;
   const reachableRuntime = new Map<string, Set<string>>();
   const resolveCache = new Map<string, string | null>();
   const loadPromises = new Map<string, Promise<void>>();
@@ -142,6 +153,7 @@ export async function buildRuntimeClassMap(
       carbonSrcPath,
       moduleKey,
       resolveCache,
+      files,
     );
 
     if (!resolvedKey) {
@@ -187,16 +199,14 @@ export async function buildRuntimeClassMap(
     const visited = new Set<string>();
     const queue = [start];
 
-    while (queue.length > 0) {
-      const current = queue.shift();
-      if (!current) {
-        continue;
-      }
+    for (let head = 0; head < queue.length; head++) {
+      const current = queue[head];
 
       const resolvedCurrent = resolveExistingModuleKey(
         carbonSrcPath,
         current,
         resolveCache,
+        files,
       );
 
       if (!resolvedCurrent || visited.has(resolvedCurrent)) {

--- a/src/plugins/css-splice-optimizer.ts
+++ b/src/plugins/css-splice-optimizer.ts
@@ -1196,3 +1196,40 @@ export function spliceOptimizeCss(
     removed: optimizer.removed,
   };
 }
+
+/**
+ * Calls `onRule` with every rule's selector in document order (the order
+ * `Root#walkRules` visits them), parsing with the splice tokenizer instead
+ * of building a PostCSS AST. Returns `false` without calling `onRule` when
+ * the stylesheet falls outside the modeled shape, so the caller can fall
+ * back to PostCSS.
+ */
+export function forEachRuleSelector(
+  css: string,
+  onRule: (selector: string) => void,
+): boolean {
+  const first = css.charCodeAt(0);
+  if (first === BOM || first === BOM_REVERSED) return false;
+
+  let root: CssNode;
+  try {
+    root = new Parser(css).parse();
+  } catch (error) {
+    if (error === BAIL) return false;
+    throw error;
+  }
+
+  const stack: CssNode[] = [root];
+  while (stack.length > 0) {
+    const node = stack.pop() as CssNode;
+    if (node.type === N_RULE) onRule(css.slice(node.a, node.b));
+    const nodes = node.nodes;
+    if (!nodes) continue;
+    for (let i = nodes.length - 1; i >= 0; i--) {
+      const child = nodes[i];
+      if (typeof child !== "number") stack.push(child);
+    }
+  }
+
+  return true;
+}

--- a/src/plugins/css-splice-optimizer.ts
+++ b/src/plugins/css-splice-optimizer.ts
@@ -75,12 +75,15 @@ const N_ROOT = 0;
 const N_RULE = 1;
 const N_AT_BLOCK = 2;
 const N_AT_STATEMENT = 3;
-const N_DECL = 4;
-const N_COMMENT = 5;
+const N_COMMENT = 4;
 
-/** `RE_WORD_END` minus the `/(?=*)` alternative, which needs a lookahead. */
+/**
+ * `RE_WORD_END`: `1` ends a word outright; `2` (`/`) ends it only when a
+ * `*` follows, i.e. the `/(?=*)` alternative that needs a lookahead.
+ */
 const WORD_END = new Uint8Array(128);
 for (const ch of "\t\n\f\r !\"#'():;@[\\]{}") WORD_END[ch.charCodeAt(0)] = 1;
+WORD_END[SLASH] = 2;
 /** `RE_AT_END`. */
 const AT_END = new Uint8Array(128);
 for (const ch of "\t\n\f\r \"#'()/;[\\]{}") AT_END[ch.charCodeAt(0)] = 1;
@@ -120,34 +123,41 @@ function isLineTerminator(code: number): boolean {
   return code === NEWLINE || code === CR || code === 0x2028 || code === 0x2029;
 }
 
+/**
+ * A container's children, in source order. Declarations are stored as
+ * non-negative indices into the parser's flat `Decls` arrays instead of as
+ * `CssNode`s: they outnumber every other node three to one in a compiled
+ * Carbon theme, are never removed on their own, and only ever need their
+ * offsets read back.
+ */
+type Child = CssNode | number;
+
 class CssNode {
   type: number;
   parent: CssNode | null;
-  nodes: CssNode[] | null;
+  nodes: Child[] | null;
   /** Offset where `raws.before` starts. */
   before: number;
   /** Offset of the first token. */
   start: number;
   /**
-   * Exclusive end. Containers: after `}`. Declarations and at-rule
-   * statements: before the `;` (if any). Comments: after `*​/`.
+   * Exclusive end. Containers: after `}`. At-rule statements: before the
+   * `;` (if any). Comments: after `*​/`.
    */
   end: number;
-  /** Declaration / at-rule statement ended with `;` in the source. */
+  /** At-rule statement ended with `;` in the source. */
   semi: boolean;
-  /** Declaration whose property starts with `--`. */
-  custom: boolean;
-  /** Rule: selector range. At-rule: params range. Declaration: value range. */
+  /** Rule: selector range. At-rule: params range. */
   a: number;
   b: number;
-  /** Declaration: property is `[start, propEnd)`. */
-  propEnd: number;
   /** At-rule name. */
   name: string;
   /** Rule: rewritten selector, or `null` when untouched. */
   selector: string | null;
   /** Container `raws.semicolon`. */
   semicolon: boolean;
+  /** Container is (or is nested in) a `@font-face` block. */
+  fontFace: boolean;
   removed: boolean;
   dirty: boolean;
 
@@ -160,16 +170,82 @@ class CssNode {
     this.start = before;
     this.end = before;
     this.semi = false;
-    this.custom = false;
     this.a = 0;
     this.b = 0;
-    this.propEnd = 0;
     this.name = "";
     this.selector = null;
     this.semicolon = false;
+    this.fontFace = parent?.fontFace === true;
     this.removed = false;
     this.dirty = false;
   }
+}
+
+const D_SEMI = 1;
+const D_CUSTOM = 2;
+
+/**
+ * Struct-of-arrays store for declarations. Per declaration: property
+ * `[start, propEnd)`, value `[a, b)`, exclusive `end` (before the `;` if
+ * any), and `D_SEMI` / `D_CUSTOM` flags. No `raws.before`: a declaration is
+ * never removed on its own, so its leading whitespace is never spliced.
+ */
+class Decls {
+  start: Int32Array;
+  propEnd: Int32Array;
+  a: Int32Array;
+  b: Int32Array;
+  end: Int32Array;
+  flags: Uint8Array;
+  count: number;
+
+  constructor(capacity: number) {
+    this.start = new Int32Array(capacity);
+    this.propEnd = new Int32Array(capacity);
+    this.a = new Int32Array(capacity);
+    this.b = new Int32Array(capacity);
+    this.end = new Int32Array(capacity);
+    this.flags = new Uint8Array(capacity);
+    this.count = 0;
+  }
+
+  push(
+    start: number,
+    propEnd: number,
+    a: number,
+    b: number,
+    end: number,
+    flags: number,
+  ): number {
+    const i = this.count;
+    if (i === this.start.length) this.grow();
+    this.start[i] = start;
+    this.propEnd[i] = propEnd;
+    this.a[i] = a;
+    this.b[i] = b;
+    this.end[i] = end;
+    this.flags[i] = flags;
+    this.count = i + 1;
+    return i;
+  }
+
+  private grow(): void {
+    const size = this.start.length * 2;
+    this.start = growInt32(this.start, size);
+    this.propEnd = growInt32(this.propEnd, size);
+    this.a = growInt32(this.a, size);
+    this.b = growInt32(this.b, size);
+    this.end = growInt32(this.end, size);
+    const flags = new Uint8Array(size);
+    flags.set(this.flags);
+    this.flags = flags;
+  }
+}
+
+function growInt32(array: Int32Array, size: number): Int32Array {
+  const next = new Int32Array(size);
+  next.set(array);
+  return next;
 }
 
 /**
@@ -398,8 +474,11 @@ class Tokenizer {
           next = pos + 1;
           while (next < length) {
             const c = css.charCodeAt(next);
-            if (c < 128 && WORD_END[c] === 1) break;
-            if (c === SLASH && css.charCodeAt(next + 1) === ASTERISK) break;
+            if (c < 128) {
+              const kind = WORD_END[c];
+              if (kind === 1) break;
+              if (kind === 2 && css.charCodeAt(next + 1) === ASTERISK) break;
+            }
             next += 1;
           }
           this.type = T_WORD;
@@ -446,6 +525,7 @@ class Parser {
   tokStarts: Int32Array;
   tokEnds: Int32Array;
   tokCount: number;
+  decls: Decls;
 
   constructor(css: string) {
     this.css = css;
@@ -458,6 +538,8 @@ class Parser {
     this.tokStarts = new Int32Array(64);
     this.tokEnds = new Int32Array(64);
     this.tokCount = 0;
+    // Compiled Carbon themes run about one declaration per 50 bytes.
+    this.decls = new Decls(Math.max(64, (css.length / 48) | 0));
   }
 
   parse(): CssNode {
@@ -532,6 +614,7 @@ class Parser {
     this.init(node);
     node.start = t.start;
     node.name = name;
+    if (name === "font-face") node.fontFace = true;
 
     const brackets: number[] = [];
     let open = false;
@@ -774,26 +857,21 @@ class Parser {
       // a bare `!important` is an empty value, and `@font-face` descriptors
       // are compared verbatim.
       if (IMPORTANT_ONLY.test(css.slice(valueFrom, valueTo))) bail();
-      for (let p: CssNode | null = this.current; p; p = p.parent) {
-        if (p.type === N_AT_BLOCK && p.name === "font-face") bail();
-      }
+      if (this.current.fontFace) bail();
     }
 
-    const node = new CssNode(N_DECL, this.current, this.spaces);
-    this.init(node);
-    node.start = starts[0];
-    node.propEnd = ends[0];
-    node.custom = customProperty;
-    node.a = valueFrom === -1 ? valueTo : valueFrom;
-    node.b = valueTo;
-    node.end = ends[count - 1];
-    node.semi = semi;
-    if (semi) {
-      this.semicolon = true;
-      this.spaces = semiEnd;
-    } else {
-      this.spaces = node.end;
-    }
+    const end = ends[count - 1];
+    const index = this.decls.push(
+      starts[0],
+      ends[0],
+      valueFrom === -1 ? valueTo : valueFrom,
+      valueTo,
+      end,
+      (semi ? D_SEMI : 0) | (customProperty ? D_CUSTOM : 0),
+    );
+    this.current.nodes?.push(index);
+    this.semicolon = semi;
+    this.spaces = semi ? semiEnd : end;
   }
 
   private end(closeEnd: number): void {
@@ -824,11 +902,13 @@ function markDirty(node: CssNode | null): void {
 
 class Optimizer {
   css: string;
+  decls: Decls;
   options: SpliceOptimizerOptions;
   removed: number;
 
-  constructor(css: string, options: SpliceOptimizerOptions) {
+  constructor(css: string, decls: Decls, options: SpliceOptimizerOptions) {
     this.css = css;
+    this.decls = decls;
     this.options = options;
     this.removed = 0;
   }
@@ -844,7 +924,7 @@ class Optimizer {
     const nodes = node.nodes;
     if (!nodes) return;
     for (const child of nodes) {
-      if (child.removed) continue;
+      if (typeof child === "number" || child.removed) continue;
       if (all || child.dirty) {
         child.dirty = false;
         this.visit(child, all);
@@ -881,24 +961,25 @@ class Optimizer {
       let family = "";
       let style = "";
       let weight = "";
-      const stack: CssNode[] = [];
+      const decls = this.decls;
+      const stack: Child[] = [];
       if (node.nodes) {
         for (let i = node.nodes.length - 1; i >= 0; i--) {
           stack.push(node.nodes[i]);
         }
       }
       while (stack.length > 0) {
-        const child = stack.pop() as CssNode;
-        if (child.removed) continue;
-        if (child.type === N_DECL) {
-          const prop = css.slice(child.start, child.propEnd);
+        const child = stack.pop() as Child;
+        if (typeof child === "number") {
+          const prop = css.slice(decls.start[child], decls.propEnd[child]);
           if (prop === "font-family") {
-            family = css.slice(child.a, child.b);
+            family = css.slice(decls.a[child], decls.b[child]);
           } else if (prop === "font-style") {
-            style = css.slice(child.a, child.b);
+            style = css.slice(decls.a[child], decls.b[child]);
           } else if (prop === "font-weight") {
-            weight = css.slice(child.a, child.b);
+            weight = css.slice(decls.a[child], decls.b[child]);
           }
+        } else if (child.removed) {
         } else if (child.nodes) {
           for (let i = child.nodes.length - 1; i >= 0; i--) {
             stack.push(child.nodes[i]);
@@ -933,6 +1014,10 @@ function discardEmpty(node: CssNode): void {
   if (!nodes) return;
   let kept = 0;
   for (const child of nodes) {
+    if (typeof child === "number") {
+      kept++;
+      continue;
+    }
     if (child.removed) continue;
     discardEmpty(child);
     if (!child.removed) kept++;
@@ -944,11 +1029,13 @@ function discardEmpty(node: CssNode): void {
 
 class Emitter {
   css: string;
+  decls: Decls;
   out: string[];
   cursor: number;
 
-  constructor(css: string) {
+  constructor(css: string, decls: Decls) {
     this.css = css;
+    this.decls = decls;
     this.out = [];
     this.cursor = 0;
   }
@@ -966,25 +1053,52 @@ class Emitter {
 
   /** Mirror of the stringifier's `pushBody` semicolon rules. */
   private body(container: CssNode): void {
-    const nodes = container.nodes as CssNode[];
+    const nodes = container.nodes as Child[];
+    const decls = this.decls;
     let keptCount = 0;
     let last = -1;
     for (const node of nodes) {
-      if (node.removed) continue;
-      if (node.type !== N_COMMENT) last = keptCount;
+      if (typeof node === "number") {
+        last = keptCount;
+      } else {
+        if (node.removed) continue;
+        if (node.type !== N_COMMENT) last = keptCount;
+      }
       keptCount++;
     }
 
     // `Root#removeChild` hands a removed first child's `raws.before` to the
     // node that takes its place, so the first surviving root node keeps the
     // stylesheet's original leading whitespace.
+    const first = nodes[0];
     const inherited =
-      container.type === N_ROOT && nodes.length > 1 && nodes[0].removed
-        ? nodes[0]
+      container.type === N_ROOT &&
+      nodes.length > 1 &&
+      typeof first !== "number" &&
+      first.removed
+        ? first
         : null;
 
     let i = 0;
     for (const node of nodes) {
+      if (typeof node === "number") {
+        if (inherited !== null && i === 0) {
+          this.out.push(this.css.slice(inherited.before, inherited.start));
+          this.cursor = decls.start[node];
+        }
+        this.statement(
+          i,
+          last,
+          keptCount,
+          container.semicolon,
+          decls.end[node],
+          (decls.flags[node] & D_SEMI) !== 0,
+          (decls.flags[node] & D_CUSTOM) !== 0,
+        );
+        i++;
+        continue;
+      }
+
       if (node.removed) {
         this.flush(node.before);
         this.cursor = node.semi ? node.end + 1 : node.end;
@@ -1005,25 +1119,46 @@ class Emitter {
         this.body(node);
       } else if (node.type === N_AT_BLOCK) {
         this.body(node);
-      } else if (node.type === N_DECL || node.type === N_AT_STATEMENT) {
-        let semicolon = i !== last || container.semicolon;
-        if (
-          !semicolon &&
-          i < keptCount - 1 &&
-          (node.type === N_AT_STATEMENT || node.custom)
-        ) {
-          semicolon = true;
-        }
-        if (semicolon !== node.semi) {
-          this.flush(node.end);
-          if (semicolon) {
-            this.out.push(";");
-          } else {
-            this.cursor = node.end + 1;
-          }
-        }
+      } else if (node.type === N_AT_STATEMENT) {
+        this.statement(
+          i,
+          last,
+          keptCount,
+          container.semicolon,
+          node.end,
+          node.semi,
+          true,
+        );
       }
       i++;
+    }
+  }
+
+  /**
+   * Semicolon after a declaration or at-rule statement. `forced` is true for
+   * at-rule statements and custom properties, which always get one when a
+   * sibling follows.
+   */
+  private statement(
+    i: number,
+    last: number,
+    keptCount: number,
+    containerSemicolon: boolean,
+    end: number,
+    semi: boolean,
+    forced: boolean,
+  ): void {
+    let semicolon = i !== last || containerSemicolon;
+    if (!semicolon && i < keptCount - 1 && forced) {
+      semicolon = true;
+    }
+    if (semicolon !== semi) {
+      this.flush(end);
+      if (semicolon) {
+        this.out.push(";");
+      } else {
+        this.cursor = end + 1;
+      }
     }
   }
 }
@@ -1044,15 +1179,20 @@ export function spliceOptimizeCss(
   // makes PostCSS strip it and emit a source map.
   if (css.includes("<") || css.includes("sourceMappingURL")) return undefined;
 
+  const parser = new Parser(css);
   let root: CssNode;
   try {
-    root = new Parser(css).parse();
+    root = parser.parse();
   } catch (error) {
     if (error === BAIL) return undefined;
     throw error;
   }
 
-  const optimizer = new Optimizer(css, options);
+  const decls = parser.decls;
+  const optimizer = new Optimizer(css, decls, options);
   optimizer.run(root);
-  return { css: new Emitter(css).emit(root), removed: optimizer.removed };
+  return {
+    css: new Emitter(css, decls).emit(root),
+    removed: optimizer.removed,
+  };
 }

--- a/src/plugins/strict-css-optimizer.ts
+++ b/src/plugins/strict-css-optimizer.ts
@@ -2,9 +2,10 @@ import type { AtRule, Rule } from "postcss";
 import { getComponents } from "../component-index-registry";
 import { ALWAYS_ON_CLASSES, CONTEXT_ANCESTORS } from "../constants";
 import {
-  getCarbonClassesFromNormalized,
+  findSubjectStart,
+  isClassTokenChar,
   splitSelectorList,
-  splitSelectorParts,
+  stripNotPseudoClasses,
 } from "../indexer/css-selector-utils";
 import { isSafelisted, type SafelistEntry } from "./safelist";
 
@@ -33,6 +34,20 @@ const FLATPICKR_SELECTOR = new RegExp(
   `\\.(?:flatpickr-[A-Za-z0-9_-]+|${FLATPICKR_CLASS_NAMES.join("|")})(?![A-Za-z0-9_-])`,
 );
 const FLATPICKR_KEYFRAMES = new Set(["fpFadeInDown"]);
+
+/**
+ * Cheap necessary condition for `FLATPICKR_SELECTOR`: every class name it
+ * matches contains an uppercase letter, except `flatpickr-*` and
+ * `cur-month`. Carbon's own selectors are lowercase, so this skips the
+ * alternation regex for nearly every rule in a Carbon theme.
+ */
+function mayHaveFlatpickr(selector: string): boolean {
+  for (let i = 0; i < selector.length; i++) {
+    const code = selector.charCodeAt(i);
+    if (code >= 65 && code <= 90) return true;
+  }
+  return selector.includes("flatpickr") || selector.includes("cur-month");
+}
 /**
  * Anything the optimizer could remove: Carbon (`bx-`) selectors, flatpickr
  * selectors and keyframes, and IBM Plex `@font-face` rules. A stylesheet
@@ -155,6 +170,56 @@ function classMatchesAllowlist(name: string, index: AllowlistIndex): boolean {
   return CONTEXT_ANCESTOR_SET.has(name) || matchesAllowlist(name, index);
 }
 
+const HYPHEN = 45;
+
+const CLASSES_NONE = 0;
+const CLASSES_MATCH = 1;
+const CLASSES_MISS = 2;
+
+/**
+ * Runs the allowlist over every Carbon class token in
+ * `normalized[from, to)` (legacy `.bx-x` read as `.bx--x`), stopping at the
+ * first miss. Same tokens `getCarbonClassesFromNormalized` yields for the
+ * compounds in that range, without materializing them: a class token never
+ * spans a combinator, so a range of whole compounds scans the same.
+ */
+function scanCarbonClasses(
+  normalized: string,
+  from: number,
+  to: number,
+  index: AllowlistIndex,
+  ancestor: boolean,
+): number {
+  let start = normalized.indexOf(".bx-", from);
+  if (start === -1 || start >= to) return CLASSES_NONE;
+
+  let result = CLASSES_NONE;
+
+  while (start !== -1 && start < to) {
+    const isCarbon = normalized.charCodeAt(start + 4) === HYPHEN;
+    const tokenStart = isCarbon ? start + 5 : start + 4;
+    let end = tokenStart;
+    while (end < to && isClassTokenChar(normalized.charCodeAt(end))) {
+      end++;
+    }
+
+    if (end > tokenStart) {
+      const name = isCarbon
+        ? normalized.slice(start, end)
+        : `.bx--${normalized.slice(tokenStart, end)}`;
+      const matched = ancestor
+        ? classMatchesAllowlist(name, index)
+        : matchesAllowlist(name, index);
+      if (!matched) return CLASSES_MISS;
+      result = CLASSES_MATCH;
+    }
+
+    start = normalized.indexOf(".bx-", end);
+  }
+
+  return result;
+}
+
 /**
  * Whether to keep this selector in strict mode.
  *
@@ -166,27 +231,27 @@ function classMatchesAllowlist(name: string, index: AllowlistIndex): boolean {
  * still require every class to match.
  */
 function shouldKeepSelector(selector: string, index: AllowlistIndex): boolean {
-  const parts = splitSelectorParts(selector);
-  const subjectClasses = getCarbonClassesFromNormalized(parts.subject);
+  const normalized = stripNotPseudoClasses(selector);
+  const subjectStart = findSubjectStart(normalized);
 
   // Most pruned rules fail on their subject, so ancestor classes are only
-  // extracted once the subject has passed (or has no Carbon class at all).
+  // checked once the subject has passed (or has no Carbon class at all).
   if (
-    subjectClasses.length > 0 &&
-    !subjectClasses.every((name) => matchesAllowlist(name, index))
+    scanCarbonClasses(
+      normalized,
+      subjectStart,
+      normalized.length,
+      index,
+      false,
+    ) === CLASSES_MISS
   ) {
     return false;
   }
 
-  if (parts.ancestors.length === 0) {
-    return true;
-  }
-
-  const ancestorClasses = parts.ancestors.flatMap((part) =>
-    getCarbonClassesFromNormalized(part),
+  return (
+    subjectStart === 0 ||
+    scanCarbonClasses(normalized, 0, subjectStart, index, true) !== CLASSES_MISS
   );
-
-  return ancestorClasses.every((name) => classMatchesAllowlist(name, index));
 }
 
 export type PrunedSelector = {
@@ -213,28 +278,32 @@ export function pruneRuleSelector(
   // selectee is also a match on the whole list, so one test on the list rules
   // it out for every selectee.
   const hasCarbon = selector.includes("bx-");
-  const hasFlatpickr = FLATPICKR_SELECTOR.test(selector);
+  const hasFlatpickr =
+    mayHaveFlatpickr(selector) && FLATPICKR_SELECTOR.test(selector);
 
   if (!(hasCarbon || hasFlatpickr)) {
     return undefined;
   }
 
+  const dropFlatpickr = hasFlatpickr && !preserveFlatpickr;
+
+  // Single selectee (the common case): no list to split or rebuild.
+  if (!selector.includes(",")) {
+    const selectee = selector.trim();
+    if (selectee === "") return { removed: 0, selector: null };
+    return keepSelectee(selectee, safelist, dropFlatpickr, index)
+      ? undefined
+      : { removed: 1, selector: null };
+  }
+
   const selectors = splitSelectorList(selector);
-  const keptSelectors = selectors.filter((selectee) => {
-    if (isSafelisted(selectee, safelist)) {
-      return true;
-    }
+  const keptSelectors: string[] = [];
 
-    if (
-      hasFlatpickr &&
-      !preserveFlatpickr &&
-      FLATPICKR_SELECTOR.test(selectee)
-    ) {
-      return false;
+  for (const selectee of selectors) {
+    if (keepSelectee(selectee, safelist, dropFlatpickr, index)) {
+      keptSelectors.push(selectee);
     }
-
-    return !selectee.includes("bx-") || shouldKeepSelector(selectee, index);
-  });
+  }
 
   if (keptSelectors.length === 0) {
     return { removed: selectors.length, selector: null };
@@ -248,6 +317,23 @@ export function pruneRuleSelector(
   }
 
   return undefined;
+}
+
+function keepSelectee(
+  selectee: string,
+  safelist: readonly SafelistEntry[],
+  dropFlatpickr: boolean,
+  index: AllowlistIndex,
+): boolean {
+  if (isSafelisted(selectee, safelist)) {
+    return true;
+  }
+
+  if (dropFlatpickr && FLATPICKR_SELECTOR.test(selectee)) {
+    return false;
+  }
+
+  return !selectee.includes("bx-") || shouldKeepSelector(selectee, index);
 }
 
 /**

--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -8,8 +8,48 @@ const NODE_MODULES_REGEX = /node_modules/;
 // Import specifiers can't contain a semicolon, so bounding the clause with
 // `[^;]` keeps the lazy match from ever crossing into a later statement,
 // without needing a stateful parser to find each declaration's extent.
+//
+// Sticky rather than global: `nextImportDeclaration` jumps to each `import`
+// occurrence with `indexOf` and matches at that line's start only, instead of
+// letting the regex crawl the whole script body after the last import.
 const IMPORT_DECLARATION_REGEX =
-  /^([ \t]*)import\s+(type\s+)?(?:([^;]*?)\s+from\s+)?["']([^"']+)["']\s*;?/gm;
+  /^([ \t]*)import\s+(type\s+)?(?:([^;]*?)\s+from\s+)?["']([^"']+)["']\s*;?/my;
+
+/** Where multiline `^` matches: after `\n`, `\r`, U+2028, U+2029. */
+function isLineTerminator(code: number): boolean {
+  return code === 10 || code === 13 || code === 0x2028 || code === 0x2029;
+}
+
+/**
+ * The next import declaration starting at or after `from`, in the same
+ * order a global `^[ \t]*import…` regex would find them: an `import` keyword
+ * preceded only by spaces/tabs since its line start.
+ */
+function nextImportDeclaration(
+  raw: string,
+  from: number,
+): RegExpExecArray | null {
+  let index = raw.indexOf("import", from);
+
+  while (index !== -1) {
+    let lineStart = index;
+    while (lineStart > from) {
+      const code = raw.charCodeAt(lineStart - 1);
+      if (code !== 32 && code !== 9) break;
+      lineStart--;
+    }
+
+    if (lineStart === 0 || isLineTerminator(raw.charCodeAt(lineStart - 1))) {
+      IMPORT_DECLARATION_REGEX.lastIndex = lineStart;
+      const match = IMPORT_DECLARATION_REGEX.exec(raw);
+      if (match !== null) return match;
+    }
+
+    index = raw.indexOf("import", index + 6);
+  }
+
+  return null;
+}
 const TYPE_SPECIFIER_PREFIX_REGEX = /^type\s+/;
 const AS_ALIAS_REGEX = /\s+as\s+/;
 const WHITESPACE_REGEX = /\s/;
@@ -146,36 +186,39 @@ function rewriteImport(
 const BASE64_CHARS =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-function encodeVlq(value: number): string {
-  let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
-  let encoded = "";
-  do {
-    let digit = vlq & 31;
-    vlq >>>= 5;
-    if (vlq > 0) digit |= 32;
-    encoded += BASE64_CHARS[digit];
-  } while (vlq > 0);
-  return encoded;
+const COMMA = 44;
+const SEMICOLON = 59;
+const BASE64_A = 65;
+
+/** Base64 digit of a one-digit VLQ (`value < 16`, non-negative). */
+const VLQ_DIGIT = new Uint8Array(16);
+for (let value = 0; value < 16; value++) {
+  VLQ_DIGIT[value] = BASE64_CHARS.charCodeAt(value << 1);
 }
 
-// Inside an untouched run of text, generated and original columns advance in
-// lockstep, so every segment after the first on a line is a delta `d` on both:
-// `,<vlq(d)>A A <vlq(d)>` (source index 0, same source line). Precomputing
-// those for realistic word/punctuation gaps turns the hot path into one
-// string append.
-const SAME_LINE_SEGMENTS = Array.from(
-  { length: 128 },
-  (_, delta) => `,${encodeVlq(delta)}AA${encodeVlq(delta)}`,
-);
-
-function isWordChar(code: number): boolean {
-  return (
+/** `[A-Za-z0-9_]`, indexed by char code. */
+const WORD_CHAR = new Uint8Array(128);
+for (let code = 0; code < 128; code++) {
+  WORD_CHAR[code] =
     (code >= 97 && code <= 122) || // a-z
     (code >= 65 && code <= 90) || // A-Z
     (code >= 48 && code <= 57) || // 0-9
     code === 95 // _
-  );
+      ? 1
+      : 0;
 }
+
+const ascii = new TextDecoder("latin1");
+
+/**
+ * Shared output buffer. `transformScript` is synchronous and never nested,
+ * so one buffer serves every call; it grows to the largest mapping built so
+ * far and is dropped back to its initial size past `SCRATCH_RETAIN_LIMIT`
+ * so one huge file doesn't pin memory for the rest of the build.
+ */
+const SCRATCH_INITIAL = 4096;
+const SCRATCH_RETAIN_LIMIT = 1 << 20;
+let scratch = new Uint8Array(SCRATCH_INITIAL);
 
 /**
  * Builds a v3 source map while the transformed code is emitted, tracking the
@@ -186,9 +229,15 @@ function isWordChar(code: number): boolean {
  * text gets a segment at the start of every word and at each non-word
  * character; each line of replacement text maps back to the start of the
  * statement it replaced.
+ *
+ * `mappings` is pure ASCII, so it is written a byte at a time into a
+ * growable buffer and decoded once at the end. Untouched text produces a
+ * segment every few characters, and appending each as a string spends most
+ * of the time building rope strings.
  */
 class MappingsBuilder {
-  private mappings = "";
+  private buffer = scratch;
+  private length = 0;
   // Original cursor (position in the input the next copy/replace consumes).
   private line = 0;
   private column = 0;
@@ -205,19 +254,30 @@ class MappingsBuilder {
     const length = text.length;
     if (length === 0) return;
 
+    // Worst case is a segment per character: `,` + digit + `AA` + digit.
+    // Longer segments (a delta of 16+) only follow a word of 16+ characters
+    // that wrote nothing, so they stay under that bound too.
+    this.reserve(length * 5 + 64);
+    const buffer = this.buffer;
+    let out = this.length;
+
+    // Generated and original columns advance in lockstep while copying, so
+    // only the original column is tracked; the generated one is `column +
+    // offset` until a newline resets both.
+    let column = this.column;
+    let offset = this.genColumn - column;
+    let prevColumn = this.prevColumn;
     let inWord = false;
     let sameLine = false;
-    let mappings = this.mappings;
-    let { column, genColumn } = this;
 
     for (let i = 0; i < length; i++) {
       const code = text.charCodeAt(i);
 
       if (code === 10) {
-        mappings += ";";
+        buffer[out++] = SEMICOLON;
         this.line++;
         column = 0;
-        genColumn = 0;
+        offset = 0;
         this.prevGenColumn = 0;
         this.lineHasSegments = false;
         inWord = false;
@@ -225,34 +285,46 @@ class MappingsBuilder {
         continue;
       }
 
-      const word = isWordChar(code);
+      const word = code < 128 && WORD_CHAR[code] === 1;
       if (!word || !inWord) {
         if (sameLine) {
-          const delta = column - this.prevColumn;
-          mappings +=
-            delta < 128
-              ? SAME_LINE_SEGMENTS[delta]
-              : `,${encodeVlq(delta)}AA${encodeVlq(delta)}`;
-          this.prevGenColumn = genColumn;
-          this.prevColumn = column;
+          // Every segment after the first on a line is a delta `d` on both
+          // columns: `,<vlq(d)>AA<vlq(d)>` (source index 0, same line).
+          const delta = column - prevColumn;
+          buffer[out++] = COMMA;
+          if (delta < 16) {
+            const digit = VLQ_DIGIT[delta];
+            buffer[out++] = digit;
+            buffer[out++] = BASE64_A;
+            buffer[out++] = BASE64_A;
+            buffer[out++] = digit;
+          } else {
+            out = writeVlq(buffer, out, delta);
+            buffer[out++] = BASE64_A;
+            buffer[out++] = BASE64_A;
+            out = writeVlq(buffer, out, delta);
+          }
+          prevColumn = column;
         } else {
-          this.mappings = mappings;
+          this.length = out;
           this.column = column;
-          this.genColumn = genColumn;
+          this.genColumn = column + offset;
+          this.prevColumn = prevColumn;
           this.addSegment();
-          mappings = this.mappings;
+          out = this.length;
+          prevColumn = column;
           sameLine = true;
         }
       }
       inWord = word;
-
       column++;
-      genColumn++;
     }
 
-    this.mappings = mappings;
+    this.length = out;
     this.column = column;
-    this.genColumn = genColumn;
+    this.genColumn = column + offset;
+    this.prevColumn = prevColumn;
+    if (sameLine) this.prevGenColumn = prevColumn + offset;
   }
 
   /**
@@ -269,7 +341,15 @@ class MappingsBuilder {
       // Each further line starts at generated column 0 and maps to the same
       // original position, so all four deltas are zero. A trailing newline
       // leaves an empty last line with no segment.
-      this.mappings += lineStart < content.length ? ";AAAA" : ";";
+      this.reserve(5);
+      const buffer = this.buffer;
+      buffer[this.length++] = SEMICOLON;
+      if (lineStart < content.length) {
+        buffer[this.length++] = BASE64_A;
+        buffer[this.length++] = BASE64_A;
+        buffer[this.length++] = BASE64_A;
+        buffer[this.length++] = BASE64_A;
+      }
       newline = content.indexOf("\n", lineStart);
     }
 
@@ -300,21 +380,48 @@ class MappingsBuilder {
   /** Adds a segment mapping the generated cursor to the original cursor. */
   private addSegment(): void {
     const { genColumn, line, column } = this;
-    this.mappings +=
-      (this.lineHasSegments ? "," : "") +
-      encodeVlq(genColumn - this.prevGenColumn) +
-      "A" +
-      encodeVlq(line - this.prevLine) +
-      encodeVlq(column - this.prevColumn);
+    // Up to three VLQs of at most 6 digits, plus separators.
+    this.reserve(25);
+    const buffer = this.buffer;
+    let out = this.length;
+    if (this.lineHasSegments) buffer[out++] = COMMA;
+    out = writeVlq(buffer, out, genColumn - this.prevGenColumn);
+    buffer[out++] = BASE64_A;
+    out = writeVlq(buffer, out, line - this.prevLine);
+    out = writeVlq(buffer, out, column - this.prevColumn);
+    this.length = out;
     this.lineHasSegments = true;
     this.prevGenColumn = genColumn;
     this.prevLine = line;
     this.prevColumn = column;
   }
 
-  toString(): string {
-    return this.mappings;
+  private reserve(bytes: number): void {
+    const needed = this.length + bytes;
+    if (needed <= this.buffer.length) return;
+    let size = this.buffer.length * 2;
+    while (size < needed) size *= 2;
+    const next = new Uint8Array(size);
+    next.set(this.buffer.subarray(0, this.length));
+    this.buffer = next;
+    if (size <= SCRATCH_RETAIN_LIMIT) scratch = next;
   }
+
+  toString(): string {
+    return ascii.decode(this.buffer.subarray(0, this.length));
+  }
+}
+
+/** Writes the base64 VLQ of `value` at `out`; returns the new offset. */
+function writeVlq(buffer: Uint8Array, out: number, value: number): number {
+  let vlq = value < 0 ? (-value << 1) | 1 : value << 1;
+  do {
+    let digit = vlq & 31;
+    vlq >>>= 5;
+    if (vlq > 0) digit |= 32;
+    buffer[out++] = BASE64_CHARS.charCodeAt(digit);
+  } while (vlq > 0);
+  return out;
 }
 
 /**
@@ -360,8 +467,7 @@ function transformScript(raw: string, filename: string) {
   let mappings: MappingsBuilder | undefined;
   let lastIndex = 0;
 
-  IMPORT_DECLARATION_REGEX.lastIndex = 0;
-  let match = IMPORT_DECLARATION_REGEX.exec(raw);
+  let match = nextImportDeclaration(raw, 0);
   while (match !== null) {
     const index = match.index;
     // `match[2]` is the `type` keyword: type-only statements
@@ -384,7 +490,7 @@ function transformScript(raw: string, filename: string) {
       lastIndex = end;
     }
 
-    match = IMPORT_DECLARATION_REGEX.exec(raw);
+    match = nextImportDeclaration(raw, index + match[0].length);
   }
 
   // Nothing rewritten: hand the content back as-is. Svelte treats a missing


### PR DESCRIPTION
The three hot paths now do the same work with fewer allocations and
passes, and the bench suite gained the cases real builds actually hit
(non-Carbon chunks, the PostCSS fallback, scripts with a body, and the
index phases in isolation). Output is byte-identical on every path: the
splice-vs-PostCSS parity suite is unchanged, source maps match the old
builder across 300 fuzzed inputs, and the regenerated component index
has no diff.

## Benchmark

Medians from `bun run bench` on an Apple M2, same machine before and
after, `.context/bench/before-full.json` vs `after-full.json`.

| Task                                          | Before  | After   | Speedup |
|-----------------------------------------------|---------|---------|---------|
| optimizeCss, Carbon theme, Button             | 8.35 ms | 6.99 ms | 1.19x   |
| optimizeCss, Carbon theme, small bundle       | 8.15 ms | 6.78 ms | 1.20x   |
| optimizeCss, Carbon theme, UIShell            | 8.29 ms | 6.95 ms | 1.19x   |
| optimizeCss, Carbon + app CSS (splice)        | 8.74 ms | 7.22 ms | 1.21x   |
| optimizeCss, Carbon as Uint8Array             | 7.57 ms | 6.56 ms | 1.15x   |
| optimizeCss, full build (4 assets)            | 9.04 ms | 7.61 ms | 1.19x   |
| optimizeImports, 11 imports + 300-line body   | 75.0 us | 40.5 us | 1.85x   |
| optimizeImports, 60+ imports + 300-line body  | 85.0 us | 49.0 us | 1.73x   |
| extractCssIndexAdditions (white.css)          | 23.2 ms | 8.12 ms | 2.86x   |
| buildComponentIndex, full rebuild             | 207 ms  | 184 ms  | 1.13x   |

Import-only scripts (no body) sit within noise of before, since the
byte buffer is reused across calls. A rough heap-growth probe on the
Carbon theme went from about 710 KB to 370 KB per call, with 13k
declaration objects replaced by typed arrays.