### PR TITLE
fix: unexport `OptimizeImportsOptions`

### DIFF
--- a/src/preprocessors/optimize-imports.ts
+++ b/src/preprocessors/optimize-imports.ts
@@ -340,7 +340,7 @@ class MappingsBuilder {
  * `src/Name/Name.svelte` path; camelCase stays on the barrel so utilities
  * don't point at a `.svelte` file that isn't there.
  */
-export type OptimizeImportsOptions = {
+type OptimizeImportsOptions = {
   experimental?: {
     /**
      * Build the component index from *this project's* installed


### PR DESCRIPTION
Keeps the src/* export surface minimal by dropping the export
keyword instead of re-exporting the type from src/index.ts. It's
still used locally to type the optimizeImports options param.