### PR TITLE
refactor(optimize-css): drop redundant Buffer.isBuffer branch

### DIFF
--- a/src/plugins/OptimizeCssPlugin.ts
+++ b/src/plugins/OptimizeCssPlugin.ts
@@ -138,11 +138,9 @@ export default class OptimizeCssPlugin {
             });
 
             for (const id of Object.keys(assets).filter(isCssFile)) {
-              const original_css = assets[id].source();
+              const original_css = assets[id].source().toString();
               const { css: optimized_css, removed } = optimizer.run(
-                Buffer.isBuffer(original_css)
-                  ? original_css.toString()
-                  : original_css,
+                original_css,
                 id,
               );
 


### PR DESCRIPTION
Buffer and string both normalize the same way through
`.toString()`, so the isBuffer check in the asset processing
loop was dead branching.